### PR TITLE
FATAL: Cookbook file libraries/mongodb.rb has a ruby syntax error: 

### DIFF
--- a/mongodb/libraries/mongodb.rb
+++ b/mongodb/libraries/mongodb.rb
@@ -65,7 +65,7 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.info("Started configuring the replicaset, this will take some time, another run should run smoothly")
       return
     end
-    if result.fetch("ok", nil) == 1:
+    if result.fetch("ok", nil) == 1
       # everything is fine, do nothing
     elsif result.fetch("errmsg", nil) == "already initialized"
       # check if both configs are the same


### PR DESCRIPTION
I was getting this error:

```
Uploading mongodb                          [0.10.0]
FATAL: Cookbook file libraries/mongodb.rb has a ruby syntax error:
FATAL: /home/reed/sb/clinical-trials/.chef/../cookbooks/mongodb/libraries/mongodb.rb:68: syntax error, unexpected ':', expecting keyword_then or ';' or '\n'
FATAL: /home/reed/sb/clinical-trials/.chef/../cookbooks/mongodb/libraries/mongodb.rb:141: syntax error, unexpected keyword_elsif, expecting keyword_end
FATAL:     elsif !result.fetch("errmsg", nil).nil?
FATAL:          ^
FATAL: /home/reed/sb/clinical-trials/.chef/../cookbooks/mongodb/libraries/mongodb.rb:258: syntax error, unexpected keyword_end, expecting $end
```

So I removed that colon and everything works.
