### PR TITLE
Allow MongoDB 1.8 version when using 10gen_repo recipe

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -47,6 +47,8 @@ corresponding platform. Currently only implemented for the Debian and Ubuntu rep
 Usage: just add `recipe[mongodb::10gen_repo]` to the node run_list *before* any other
 MongoDB recipe, and the mongodb-10gen **stable** packages will be installed instead of the distribution default.
 
+If `node['mongodb']['version_18_10gen']` is set to true, the 1.8.x branch will be installed from the 10gen repository.
+
 ## Single mongodb instance
 
 Simply add

--- a/mongodb/attributes/default.rb
+++ b/mongodb/attributes/default.rb
@@ -28,3 +28,6 @@ default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
 
 default[:mongodb][:enable_rest] = false
+
+# Allow using the 1.8 branch with 10gen_repo
+default[:mongodb][:version_18_10gen] = false

--- a/mongodb/metadata.json
+++ b/mongodb/metadata.json
@@ -89,6 +89,19 @@
       "description": "Enable the ReST interface of the webserver",
       "display_name": "Enable Rest"
     },
+    "mongodb/version_18_10gen": {
+      "required": "optional",
+      "calculated": false,
+      "choice": [
+
+      ],
+      "type": "string",
+      "recipes": [
+
+      ],
+      "description": "When using the 10gen repo, use the 1.8 branch instead of the latest",
+      "display_name": "Use 10gen v1.8"
+    },
     "mongodb/cluster_name": {
       "required": "optional",
       "calculated": false,

--- a/mongodb/metadata.json
+++ b/mongodb/metadata.json
@@ -95,6 +95,7 @@
       "choice": [
 
       ],
+      default: "false",
       "type": "string",
       "recipes": [
 

--- a/mongodb/metadata.rb
+++ b/mongodb/metadata.rb
@@ -60,3 +60,8 @@ attribute "mongodb/replicaset_name",
 attribute "mongodb/enable_rest",
   :display_name => "Enable Rest",
   :description => "Enable the ReST interface of the webserver"
+
+attribute "mongodb/version_18_10gen",
+  :display_name => "Use 10gen v1.8",
+  :description => "When using the 10gen repo, use the 1.8 branch instead of the latest",
+  :default => false

--- a/mongodb/metadata.rb
+++ b/mongodb/metadata.rb
@@ -64,4 +64,4 @@ attribute "mongodb/enable_rest",
 attribute "mongodb/version_18_10gen",
   :display_name => "Use 10gen v1.8",
   :description => "When using the 10gen repo, use the 1.8 branch instead of the latest",
-  :default => false
+  :default => "false"

--- a/mongodb/recipes/10gen_repo.rb
+++ b/mongodb/recipes/10gen_repo.rb
@@ -40,7 +40,12 @@ when "debian", "ubuntu"
   end
 
   package "mongodb" do
-    package_name "mongodb-10gen"
+    if node['mongodb']['version_18_10gen']
+      package_name "mongodb18-10gen"
+      options "--force-yes"
+    else
+      package_name "mongodb-10gen"
+    end
   end
 else
     Chef::Log.warn("Adding the #{node['platform']} 10gen repository is not yet not supported by this cookbook")


### PR DESCRIPTION
Default should be the latest version, but as long as we're only distributing through packages without being able to use specific versions, this was helpful to me.

The `--force-yes` is required otherwise the install bombs out with:

```
WARNING: The following packages cannot be authenticated!
  mongodb18-10gen
E: There are problems and -y was used without --force-yes
```
