### PR TITLE
Added attribute bind_ip to enable configuration of listening ip address

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -29,6 +29,7 @@ For examples see the USAGE section below.
 
 * `mongodb[:dbpath]` - Location for mongodb data directory, defaults to "/var/lib/mongodb"
 * `mongodb[:logpath]` - Path for the logfiles, default is "/var/log/mongodb"
+* `mongodb[:bind_ip]` - IP address the mongod listens on, default is node[:ipaddress]
 * `mongodb[:port]` - Port the mongod listens on, default is 27017
 * `mongodb[:client_role]` - Role identifing all external clients which should have access to a mongod instance
 * `mongodb[:cluster_name]` - Name of the cluster, all members of the cluster must
@@ -56,7 +57,7 @@ include_recipe "mongodb::default"
 ```
   
 to your recipe. This will run the mongodb instance as configured by your distribution.
-You can change the dbpath, logpath and port settings (see ATTRIBUTES) for this node by
+You can change the dbpath, logpath, bind_ip and port settings (see ATTRIBUTES) for this node by
 using the `mongodb_instance` definition:
 
 ```ruby

--- a/mongodb/attributes/default.rb
+++ b/mongodb/attributes/default.rb
@@ -19,6 +19,7 @@
 
 default[:mongodb][:dbpath] = "/var/lib/mongodb"
 default[:mongodb][:logpath] = "/var/log/mongodb"
+default[:mongodb][:bind_ip] = node[:ipaddress]
 default[:mongodb][:port] = 27017
 
 # cluster identifier

--- a/mongodb/definitions/mongodb.rb
+++ b/mongodb/definitions/mongodb.rb
@@ -19,10 +19,10 @@
 # limitations under the License.
 #
 
-define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start], :port => 27017 , \
-    :logpath => "/var/log/mongodb", :dbpath => "/data", :configfile => "/etc/mongodb.conf", \
-    :configserver => [], :replicaset => nil, :enable_rest => false, \
-    :notifies => [] do
+define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start],
+    :bind_ip => "0.0.0.0", :port => 27017 , :logpath => "/var/log/mongodb",
+    :dbpath => "/data", :configfile => "/etc/mongodb.conf", :configserver => [],
+    :replicaset => nil, :enable_rest => false, :notifies => [] do
     
   include_recipe "mongodb::default"
   
@@ -31,6 +31,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   service_action = params[:action]
   service_notifies = params[:notifies]
   
+  bind_ip = params[:bind_ip]
   port = params[:port]
 
   logpath = params[:logpath]
@@ -94,6 +95,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       "name" => name,
       "config" => configfile,
       "configdb" => configserver,
+      "bind_ip" => bind_ip,
       "port" => port,
       "logpath" => logfile,
       "dbpath" => dbpath,

--- a/mongodb/metadata.rb
+++ b/mongodb/metadata.rb
@@ -2,7 +2,7 @@ maintainer        "edelight GmbH"
 maintainer_email  "markus.korn@edelight.de"
 license           "Apache 2.0"
 description       "Installs and configures mongodb"
-version           "0.11"
+version           "0.12"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"

--- a/mongodb/recipes/default.rb
+++ b/mongodb/recipes/default.rb
@@ -37,6 +37,7 @@ if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
   # configure default instance
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
+    bind_ip      node['mongodb']['bind_ip']
     port         node['mongodb']['port']
     logpath      node['mongodb']['logpath']
     dbpath       node['mongodb']['dbpath']

--- a/mongodb/templates/default/mongodb.default.erb
+++ b/mongodb/templates/default/mongodb.default.erb
@@ -6,6 +6,7 @@ NAME="<%= @name %>"
 
 DAEMON_OPTS=""
 
+<%= @bind_ip ? "DAEMON_OPTS=\"$DAEMON_OPTS --bind_ip #{@bind_ip}\"" : "" %>
 <%= @port ? "DAEMON_OPTS=\"$DAEMON_OPTS --port #{@port}\"" : "" %>
 <%= @dbpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --dbpath #{@dbpath}\"" : "" %>
 <%= @logpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --logpath #{@logpath}\"" : "" %>


### PR DESCRIPTION
Hi,

just discovered that MongoDB comes listening to all audiences and with no authentication configured when using your cookbook. Had a couple of options ranging from mentioning this in README.md to make use of this cookbook only in trusted environments to integration of MongoDB's basic auth mechanisms.
Decided to go the way of small efforts and integrated the bind_ip directive. Default is: node[:ipaddress] which doesn't change much, but can be easily overwritten within roles e.g. to localhost.

Didn't really get what the mongodb_instance definition at the beginning of mongodb/definitions/mongodb.rb was ment for, so I've decided to add :bind_ip => "0.0.0.0" to not break anything.

Tested on Debian Squeeze with a couple of chef runs, works fine for me.

Regards,
Mike
