### PR TITLE
Support for keyFile configuration

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -36,6 +36,7 @@ For examples see the USAGE section below.
     members of a cluster.
 * `mongodb[:shard_name]` - Name of a shard, default is "default"
 * `mongodb[:sharded_collections]` - Define which collections are sharded
+* `mongodb[:key_file]` - Contents of the keyFile used for internal communication between authenticated instances
 
 # USAGE:
 

--- a/mongodb/attributes/default.rb
+++ b/mongodb/attributes/default.rb
@@ -27,4 +27,6 @@ default[:mongodb][:cluster_name] = nil
 default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
 
+default[:mongodb][:key_file] = nil
+
 default[:mongodb][:enable_rest] = false

--- a/mongodb/definitions/mongodb.rb
+++ b/mongodb/definitions/mongodb.rb
@@ -47,19 +47,19 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       replicaset_name = nil
     else
       # for replicated shards we autogenerate the replicaset name for each shard
-      replicaset_name = "rs_#{replicaset['mongodb']['shard_name']}"
+      replicaset_name = "rs_#{replicaset.mongodb.shard_name}"
     end
   else
     # if there is a predefined replicaset name we use it,
     # otherwise we try to generate one using 'rs_$SHARD_NAME'
     begin
-      replicaset_name = replicaset['mongodb']['replicaset_name']
+      replicaset_name = replicaset.mongodb.replicaset_name
     rescue
       replicaset_name = nil
     end
     if replicaset_name.nil?
       begin
-        replicaset_name = "rs_#{replicaset['mongodb']['shard_name']}"
+        replicaset_name = "rs_#{replicaset.mongodb.shard_name}"
       rescue
         replicaset_name = nil
       end
@@ -79,7 +79,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     daemon = "/usr/bin/mongos"
     configfile = nil
     dbpath = nil
-    configserver = configserver_nodes.collect{|n| "#{n['fqdn']}:#{n['mongodb']['port']}" }.join(",")
+    configserver = configserver_nodes.collect{|n| "#{n.fqdn}:#{n.mongodb.port}" }.join(",")
   end
 
   # default file

--- a/mongodb/definitions/mongodb.rb
+++ b/mongodb/definitions/mongodb.rb
@@ -23,24 +23,24 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     :logpath => "/var/log/mongodb", :dbpath => "/data", :configfile => "/etc/mongodb.conf", \
     :configserver => [], :replicaset => nil, :enable_rest => false, \
     :notifies => [] do
-    
+
   include_recipe "mongodb::default"
-  
+
   name = params[:name]
   type = params[:mongodb_type]
   service_action = params[:action]
   service_notifies = params[:notifies]
-  
+
   port = params[:port]
 
   logpath = params[:logpath]
   logfile = "#{logpath}/#{name}.log"
-  
+
   dbpath = params[:dbpath]
-  
+
   configfile = params[:configfile]
   configserver_nodes = params[:configserver]
-  
+
   replicaset = params[:replicaset]
   if type == "shard"
     if replicaset.nil?
@@ -65,11 +65,11 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       end
     end
   end
-  
+
   if !["mongod", "shard", "configserver", "mongos"].include?(type)
     raise "Unknown mongodb type '#{type}'"
   end
-  
+
   if type != "mongos"
     daemon = "/usr/bin/mongod"
     configserver = nil
@@ -81,7 +81,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     dbpath = nil
     configserver = configserver_nodes.collect{|n| "#{n['fqdn']}:#{n['mongodb']['port']}" }.join(",")
   end
-  
+
   # default file
   template "/etc/default/#{name}" do
     action :create
@@ -104,7 +104,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     )
     notifies :restart, "service[#{name}]"
   end
-  
+
   # log dir [make sure it exists]
   directory logpath do
     owner "mongodb"
@@ -113,7 +113,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     action :create
     recursive true
   end
-  
+
   if type != "mongos"
     # dbpath dir [make sure it exists]
     directory dbpath do
@@ -124,7 +124,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       recursive true
     end
   end
-  
+
   # init script
   template "/etc/init.d/#{name}" do
     action :create
@@ -135,7 +135,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     variables :provides => name
     notifies :restart, "service[#{name}]"
   end
-  
+
   # service
   service name do
     supports :status => true, :restart => true
@@ -152,7 +152,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       ignore_failure true
     end
   end
-  
+
   # replicaset
   if !replicaset_name.nil?
     rs_nodes = search(
@@ -162,7 +162,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
        mongodb_shard_name:#{replicaset['mongodb']['shard_name']} AND \
        chef_environment:#{replicaset.chef_environment}"
     )
-  
+
     ruby_block "config_replicaset" do
       block do
         if not replicaset.nil?
@@ -172,19 +172,19 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       action :nothing
     end
   end
-  
+
   # sharding
   if type == "mongos"
     # add all shards
     # configure the sharded collections
-    
+
     shard_nodes = search(
       :node,
       "mongodb_cluster_name:#{node['mongodb']['cluster_name']} AND \
        recipes:mongodb\\:\\:shard AND \
        chef_environment:#{node.chef_environment}"
     )
-    
+
     ruby_block "config_sharding" do
       block do
         if type == "mongos"

--- a/mongodb/libraries/mongodb.rb
+++ b/mongodb/libraries/mongodb.rb
@@ -38,29 +38,29 @@ class Chef::ResourceDefinitionList::MongoDB
     end
 
     begin
-      connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
+      connection = Mongo::Connection.new('localhost', node.mongodb.port, :op_timeout => 5, :slave_ok => true)
     rescue
-      Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
+      Chef::Log.warn("Could not connect to database: 'localhost:#{node.mongodb.port}'")
       return
     end
 
-    members.sort!{ |x,y| x['name'] <=> y['name'] }
+    members.sort! {|x,y| x.name <=> y.name}
     rs_members = []
     members.each_index do |n|
-      port = members[n]['mongodb']['port']
+      port = members[n].mongodb.port
       port += 1 if members[n][:mongodb][:arbiter]
-      rs_members << {"_id" => n, "host" => "#{members[n]['fqdn']}:#{port}"}
+      rs_members << {"_id" => n, "host" => "#{members[n].fqdn}:#{port}"}
     end
 
     Chef::Log.info(
-      "Configuring replicaset with members #{members.collect{ |n| n['hostname'] }.join(', ')}"
+      "Configuring replicaset with members #{rs_members.map {|m| m['host']}.join(', ')}"
     )
 
     rs_member_ips = []
     members.each_index do |n|
-      port = members[n]['mongodb']['port']
+      port = members[n].mongodb.port
       port += 1 if members[n][:mongodb][:arbiter]
-      rs_member_ips << {"_id" => n, "host" => "#{members[n]['ipaddress']}:#{port}"}
+      rs_member_ips << {"_id" => n, "host" => "#{members[n].ipaddress}:#{port}"}
     end
 
     admin = connection['admin']
@@ -92,8 +92,8 @@ class Chef::ResourceDefinitionList::MongoDB
         rs_member_ips.each do |mem_h|
           members.each do |n|
             ip, prt = mem_h['host'].split(":")
-            if ip == n['ipaddress']
-              mapping["#{ip}:#{prt}"] = "#{n['fqdn']}:#{prt}"
+            if ip == n.ipaddress
+              mapping["#{ip}:#{prt}"] = "#{n.fqdn}:#{prt}"
             end
           end
         end
@@ -109,7 +109,7 @@ class Chef::ResourceDefinitionList::MongoDB
           result = admin.command(cmd, :check_response => false)
         rescue Mongo::ConnectionFailure
           # reconfiguring destroys exisiting connections, reconnect
-          Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
+          Mongo::Connection.new('localhost', node.mongodb.port, :op_timeout => 5, :slave_ok => true)
           config = connection['local']['system']['replset'].find_one({"_id" => name})
           Chef::Log.info("New config successfully applied: #{config.inspect}")
         end
@@ -141,7 +141,7 @@ class Chef::ResourceDefinitionList::MongoDB
           result = admin.command(cmd, :check_response => false)
         rescue Mongo::ConnectionFailure
           # reconfiguring destroys exisiting connections, reconnect
-          Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
+          Mongo::Connection.new('localhost', node.mongodb.port, :op_timeout => 5, :slave_ok => true)
           config = connection['local']['system']['replset'].find_one({"_id" => name})
           Chef::Log.info("New config successfully applied: #{config.inspect}")
         end
@@ -162,12 +162,12 @@ class Chef::ResourceDefinitionList::MongoDB
     shard_groups = Hash.new{|h,k| h[k] = []}
 
     shard_nodes.each do |n|
-      if n['recipes'].include?('mongodb::replicaset')
-        key = "rs_#{n['mongodb']['shard_name']}"
+      if n.recipes.include?('mongodb::replicaset')
+        key = "rs_#{n.mongodb.shard_name}"
       else
         key = '_single'
       end
-      shard_groups[key] << "#{n['fqdn']}:#{n['mongodb']['port']}"
+      shard_groups[key] << "#{n.fqdn}:#{n.mongodb.port}"
     end
     Chef::Log.info(shard_groups.inspect)
 
@@ -182,9 +182,9 @@ class Chef::ResourceDefinitionList::MongoDB
     Chef::Log.info(shard_members.inspect)
 
     begin
-      connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
+      connection = Mongo::Connection.new('localhost', node.mongodb.port, :op_timeout => 5)
     rescue Exception => e
-      Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
+      Chef::Log.warn("Could not connect to database: 'localhost:#{node.mongodb.port}', reason #{e}")
       return
     end
 
@@ -208,9 +208,9 @@ class Chef::ResourceDefinitionList::MongoDB
     require 'mongo'
 
     begin
-      connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
+      connection = Mongo::Connection.new('localhost', node.mongodb.port, :op_timeout => 5)
     rescue Exception => e
-      Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
+      Chef::Log.warn("Could not connect to database: 'localhost:#{node.mongodb.port}', reason #{e}")
       return
     end
 

--- a/mongodb/libraries/mongodb.rb
+++ b/mongodb/libraries/mongodb.rb
@@ -27,7 +27,7 @@ class Chef::ResourceDefinitionList::MongoDB
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     if members.length == 0
       if Chef::Config[:solo]
         abort("Cannot configure replicaset '#{name}', no member nodes found")
@@ -36,38 +36,40 @@ class Chef::ResourceDefinitionList::MongoDB
         return
       end
     end
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
     rescue
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
       return
     end
-    
+
     members.sort!{ |x,y| x['name'] <=> y['name'] }
     rs_members = []
     members.each_index do |n|
       port = members[n]['mongodb']['port']
+      port += 1 if members[n][:mongodb][:arbiter]
       rs_members << {"_id" => n, "host" => "#{members[n]['fqdn']}:#{port}"}
     end
-    
+
     Chef::Log.info(
       "Configuring replicaset with members #{members.collect{ |n| n['hostname'] }.join(', ')}"
     )
-    
+
     rs_member_ips = []
     members.each_index do |n|
       port = members[n]['mongodb']['port']
+      port += 1 if members[n][:mongodb][:arbiter]
       rs_member_ips << {"_id" => n, "host" => "#{members[n]['ipaddress']}:#{port}"}
     end
-    
+
     admin = connection['admin']
     cmd = BSON::OrderedHash.new
     cmd['replSetInitiate'] = {
         "_id" => name,
         "members" => rs_members
     }
-    
+
     begin
       result = admin.command(cmd, :check_response => false)
     rescue Mongo::OperationTimeout
@@ -97,7 +99,7 @@ class Chef::ResourceDefinitionList::MongoDB
         end
         config['members'].collect!{ |m| {"_id" => m["_id"], "host" => mapping[m["host"]]} }
         config['version'] += 1
-        
+
         rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
         admin = rs_connection['admin']
         cmd = BSON::OrderedHash.new
@@ -120,20 +122,20 @@ class Chef::ResourceDefinitionList::MongoDB
         rs_members.collect!{ |member| member['host'] }
         config['version'] += 1
         old_members = config['members'].collect{ |member| member['host'] }
-        members_delete = old_members - rs_members        
+        members_delete = old_members - rs_members
         config['members'] = config['members'].delete_if{ |m| members_delete.include?(m['host']) }
         members_add = rs_members - old_members
         members_add.each do |m|
           max_id += 1
           config['members'] << {"_id" => max_id, "host" => m}
         end
-        
+
         rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
         admin = rs_connection['admin']
-        
+
         cmd = BSON::OrderedHash.new
         cmd['replSetReconfig'] = config
-        
+
         result = nil
         begin
           result = admin.command(cmd, :check_response => false)
@@ -151,14 +153,14 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.error("Failed to configure replicaset, reason: #{result.inspect}")
     end
   end
-  
+
   def self.configure_shards(node, shard_nodes)
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     shard_groups = Hash.new{|h,k| h[k] = []}
-    
+
     shard_nodes.each do |n|
       if n['recipes'].include?('mongodb::replicaset')
         key = "rs_#{n['mongodb']['shard_name']}"
@@ -168,7 +170,7 @@ class Chef::ResourceDefinitionList::MongoDB
       shard_groups[key] << "#{n['fqdn']}:#{n['mongodb']['port']}"
     end
     Chef::Log.info(shard_groups.inspect)
-    
+
     shard_members = []
     shard_groups.each do |name, members|
       if name == "_single"
@@ -178,16 +180,16 @@ class Chef::ResourceDefinitionList::MongoDB
       end
     end
     Chef::Log.info(shard_members.inspect)
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
     rescue Exception => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
       return
     end
-    
+
     admin = connection['admin']
-    
+
     shard_members.each do |shard|
       cmd = BSON::OrderedHash.new
       cmd['addShard'] = shard
@@ -199,24 +201,24 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.info(result.inspect)
     end
   end
-  
+
   def self.configure_sharded_collections(node, sharded_collections)
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
     rescue Exception => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
       return
     end
-    
+
     admin = connection['admin']
-    
+
     databases = sharded_collections.keys.collect{ |x| x.split(".").first}.uniq
     Chef::Log.info("enable sharding for these databases: '#{databases.inspect}'")
-    
+
     databases.each do |db_name|
       cmd = BSON::OrderedHash.new
       cmd['enablesharding'] = db_name
@@ -238,7 +240,7 @@ class Chef::ResourceDefinitionList::MongoDB
         Chef::Log.info("Enabled sharding for database '#{db_name}'")
       end
     end
-    
+
     sharded_collections.each do |name, key|
       cmd = BSON::OrderedHash.new
       cmd['shardcollection'] = name
@@ -261,7 +263,7 @@ class Chef::ResourceDefinitionList::MongoDB
         Chef::Log.info("Sharding for collection '#{result['collectionsharded']}' enabled")
       end
     end
-  
+
   end
-  
+
 end

--- a/mongodb/metadata.rb
+++ b/mongodb/metadata.rb
@@ -2,7 +2,7 @@ maintainer        "edelight GmbH"
 maintainer_email  "markus.korn@edelight.de"
 license           "Apache 2.0"
 description       "Installs and configures mongodb"
-version           "0.11"
+version           "0.11.1"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"
@@ -21,22 +21,22 @@ attribute "mongodb/dbpath",
   :display_name => "dbpath",
   :description => "Path to store the mongodb data",
   :default => "/var/lib/mongodb"
-  
+
 attribute "mongodb/logpath",
   :display_name => "logpath",
   :description => "Path to store the logfiles of a mongodb instance",
   :default => "/var/log/mongodb"
-  
+
 attribute "mongodb/port",
   :display_name => "Port",
   :description => "Port the mongodb instance is running on",
   :default => "27017"
-  
+
 attribute "mongodb/client_roles",
   :display_name => "Client Roles",
   :description => "Roles of nodes who need access to the mongodb instance",
   :default => []
-  
+
 attribute "mongodb/cluster_name",
   :display_name => "Cluster Name",
   :description => "Name of the mongodb cluster, all nodes of a cluster must have the same name.",
@@ -45,8 +45,8 @@ attribute "mongodb/cluster_name",
 attribute "mongodb/shard_name",
   :display_name => "Shard name",
   :description => "Name of a mongodb shard",
-  :default => "default"  
-  
+  :default => "default"
+
 attribute "mongodb/sharded_collections",
   :display_name => "Sharded Collections",
   :description => "collections to shard",
@@ -56,7 +56,12 @@ attribute "mongodb/replicaset_name",
   :display_name => "Replicaset_name",
   :description => "Name of a mongodb replicaset",
   :default => nil
-  
+
+attribute "mongodb/key_file",
+  :display_name => "keyFile",
+  :description => "Contents of the keyFile used for internal communication between authenticated instances",
+  :default => nil
+
 attribute "mongodb/enable_rest",
   :display_name => "Enable Rest",
   :description => "Enable the ReST interface of the webserver"

--- a/mongodb/metadata.rb
+++ b/mongodb/metadata.rb
@@ -2,7 +2,7 @@ maintainer        "edelight GmbH"
 maintainer_email  "markus.korn@edelight.de"
 license           "Apache 2.0"
 description       "Installs and configures mongodb"
-version           "0.11.1"
+version           "0.11.2"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"
@@ -55,6 +55,11 @@ attribute "mongodb/sharded_collections",
 attribute "mongodb/replicaset_name",
   :display_name => "Replicaset_name",
   :description => "Name of a mongodb replicaset",
+  :default => nil
+
+attribute "mongodb/arbiter",
+  :display_name => "Arbiter",
+  :description => "Whether this replicaset node is an arbiter",
   :default => nil
 
 attribute "mongodb/key_file",

--- a/mongodb/recipes/configserver.rb
+++ b/mongodb/recipes/configserver.rb
@@ -21,9 +21,13 @@
 
 include_recipe "mongodb"
 
-service "mongodb" do
-  supports :status => true, :restart => true
-  action [:disable, :stop]
+# disable and stop the default mongodb instance if we are not configured
+# as an arbiter member of a replicaset as well
+unless node.recipes.include?("mongodb::replicaset") and node[:mongodb][:arbiter]
+  service "mongodb" do
+    supports :status => true, :restart => true
+    action [:disable, :stop]
+  end
 end
 
 # we are not starting the configserver service with the --configsvr

--- a/mongodb/recipes/default.rb
+++ b/mongodb/recipes/default.rb
@@ -33,6 +33,17 @@ if needs_mongo_gem
   Gem.clear_paths
 end
 
+# Create keyFile if specified
+if node[:mongodb][:key_file]
+  file "/etc/mongodb.key" do
+    owner "mongodb"
+    group "mongodb"
+    mode  "0600"
+    backup false
+    content node[:mongodb][:key_file]
+  end
+end
+
 if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
   # configure default instance
   mongodb_instance "mongodb" do

--- a/mongodb/recipes/replicaset.rb
+++ b/mongodb/recipes/replicaset.rb
@@ -23,9 +23,9 @@ include_recipe "mongodb"
 if !node.recipes.include?("mongodb::shard")
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
-    port         node['mongodb']['port']
+    port         node['mongodb']['port'] + (node[:mongodb][:arbiter] ? 1 : 0)
     logpath      node['mongodb']['logpath']
-    dbpath       node['mongodb']['dbpath']
+    dbpath       node['mongodb']['dbpath'] + (node[:mongodb][:arbiter] ? '/arbiter' : '')
     replicaset   node
     enable_rest  node['mongodb']['enable_rest']
   end

--- a/mongodb/templates/default/mongodb.default.erb
+++ b/mongodb/templates/default/mongodb.default.erb
@@ -20,6 +20,10 @@ DAEMON_OPTS=""
 DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 <% end %>
 
+<% if node[:mongodb][:key_file] %>
+DAEMON_OPTS="$DAEMON_OPTS --keyFile /etc/mongodb.key"
+<% end %>
+
 <% if @enable_rest %>
 DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% end %>

--- a/mongodb/templates/default/mongodb.default.erb
+++ b/mongodb/templates/default/mongodb.default.erb
@@ -20,6 +20,10 @@ DAEMON_OPTS=""
 DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 <% end %>
 
+<% if @name == "mongodb" and node[:mongodb][:arbiter] %>
+DAEMON_OPTS="$DAEMON_OPTS --nojournal"
+<% end %>
+
 <% if node[:mongodb][:key_file] %>
 DAEMON_OPTS="$DAEMON_OPTS --keyFile /etc/mongodb.key"
 <% end %>


### PR DESCRIPTION
When you set up a MongoDB cluster with authentication you need to set the `keyFile` configuration. See [MongoDB docs](http://www.mongodb.org/display/DOCS/Security+and+Authentication#SecurityandAuthentication-AbouttheKeyFile).

In this commit I've added support for this.
