### PR TITLE
Add option to use mongodb config file

### DIFF
--- a/mongodb/attributes/default.rb
+++ b/mongodb/attributes/default.rb
@@ -28,6 +28,7 @@ default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
 
 default[:mongodb][:enable_rest] = false
+default[:mongodb][:use_config_file] = false
 
 case node['platform']
 when "freebsd"

--- a/mongodb/definitions/mongodb.rb
+++ b/mongodb/definitions/mongodb.rb
@@ -21,7 +21,7 @@
 
 define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start], :port => 27017 , \
     :logpath => "/var/log/mongodb", :dbpath => "/data", :configfile => "/etc/mongodb.conf", \
-    :configserver => [], :replicaset => nil, :enable_rest => false, \
+    :use_config_file => false, :configserver => [], :replicaset => nil, :enable_rest => false, \
     :notifies => [] do
     
   include_recipe "mongodb::default"
@@ -39,6 +39,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   dbpath = params[:dbpath]
   
   configfile = params[:configfile]
+  use_config_file = params[:use_config_file]
   configserver_nodes = params[:configserver]
   
   replicaset = params[:replicaset]
@@ -73,11 +74,10 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   if type != "mongos"
     daemon = "/usr/bin/mongod"
     configserver = nil
-    configfile = nil
-    Chef::Log.warn("We are not using a configfile, as the daemons can be configured via commandline")
+    configfile = nil unless use_config_file
   else
     daemon = "/usr/bin/mongos"
-    configfile = nil
+    configfile = nil unless use_config_file
     dbpath = nil
     configserver = configserver_nodes.collect{|n| "#{n['fqdn']}:#{n['mongodb']['port']}" }.join(",")
   end

--- a/mongodb/recipes/default.rb
+++ b/mongodb/recipes/default.rb
@@ -37,9 +37,10 @@ if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
   # configure default instance
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
-    port         node['mongodb']['port']
-    logpath      node['mongodb']['logpath']
-    dbpath       node['mongodb']['dbpath']
-    enable_rest  node['mongodb']['enable_rest']
+    port              node['mongodb']['port']
+    logpath           node['mongodb']['logpath']
+    dbpath            node['mongodb']['dbpath']
+    enable_rest       node['mongodb']['enable_rest']
+    use_config_file   node['mongodb']['use_config_file']
   end
 end


### PR DESCRIPTION
Right now, there doesn't seem to be a way to run mongodb with a config file because of lines 76 and 80 in mongodb/definitions/mongodb.rb. I understand that it is preferable to use the command line configuration, but if there are settings like authentication that need to be turned on, having the option to use the config file would be useful.
