### PR TITLE
mongodb single instance will no longer spit out errors

### DIFF
--- a/mongodb/definitions/mongodb.rb
+++ b/mongodb/definitions/mongodb.rb
@@ -147,10 +147,6 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     if type == "mongos"
       notifies :create, "ruby_block[config_sharding]", :immediately
     end
-    if name == "mongodb"
-      # we don't care about a running mongodb service in these cases, all we need is stopping it
-      ignore_failure true
-    end
   end
   
   # replicaset

--- a/mongodb/recipes/default.rb
+++ b/mongodb/recipes/default.rb
@@ -23,6 +23,11 @@ package "mongodb" do
   action :install
 end
 
+# stop the service if it was started by install
+service "mongodb" do
+  action :stop
+end
+
 needs_mongo_gem = (node.recipes.include?("mongodb::replicaset") or node.recipes.include?("mongodb::mongos"))
 
 if needs_mongo_gem

--- a/mongodb/recipes/default.rb
+++ b/mongodb/recipes/default.rb
@@ -21,11 +21,7 @@
 
 package "mongodb" do
   action :install
-end
-
-# stop the service if it was started by install
-service "mongodb" do
-  action :stop
+  notifies :stop, "server[mongodb]", :immediately
 end
 
 needs_mongo_gem = (node.recipes.include?("mongodb::replicaset") or node.recipes.include?("mongodb::mongos"))


### PR DESCRIPTION
The package "mongodb" was starting the service, so after install, stop the service, then you will not have any errors from trying to use a different init.d to stop/restart servers.
