### PR TITLE
More cmd flags

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,9 @@ default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
 
 default[:mongodb][:enable_rest] = false
+default[:mongodb][:enable_directoryperdb] = false
+default[:mongodb][:enable_noprealloc] = false
+default[:mongodb][:enable_smallfiles] = false
 
 default[:mongodb][:user] = "mongodb"
 default[:mongodb][:group] = "mongodb"

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -19,10 +19,21 @@
 # limitations under the License.
 #
 
-define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start],
-    :bind_ip => nil, :port => 27017 , :logpath => "/var/log/mongodb",
-    :dbpath => "/data", :configfile => "/etc/mongodb.conf", :configserver => [],
-    :replicaset => nil, :enable_rest => false, :notifies => [] do
+define :mongodb_instance,
+    :mongodb_type => "mongod",
+    :action => [:enable, :start],
+    :bind_ip => nil,
+    :port => 27017,
+    :logpath => "/var/log/mongodb",
+    :dbpath => "/data",
+    :configfile => "/etc/mongodb.conf",
+    :configserver => [],
+    :replicaset => nil,
+    :enable_rest => false,
+    :enable_directoryperdb => false,
+    :enable_noprealloc => false,
+    :enable_smallfiles => false,
+    :notifies => [] do
     
   include_recipe "mongodb::default"
   
@@ -101,7 +112,10 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       "replicaset_name" => replicaset_name,
       "configsrv" => false, #type == "configserver", this might change the port
       "shardsrv" => false,  #type == "shard", dito.
-      "enable_rest" => params[:enable_rest]
+      "enable_rest" => params[:enable_rest],
+      "enable_directoryperdb" => params[:enable_directoryperdb],
+      "enable_noprealloc" => params[:enable_noprealloc],
+      "enable_smallfiles" => params[:enable_smallfiles]
     )
     notifies :restart, "service[#{name}]"
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -67,3 +67,15 @@ attribute "mongodb/bind_ip",
   :display_name => "Bind address",
   :description => "MongoDB instance bind address",
   :default => nil
+
+attribute "mongodb/enable_directoryperdb",
+  :display_name => "Enable directory per DB",
+  :description => "Use a separate directory for the files of each database"
+
+attribute "mongodb/enable_noprealloc",
+  :display_name => "Enable noprealloc",
+  :description => "Disable data file preallocation"
+
+attribute "mongodb/enable_smallfiles",
+  :display_name => "Enable smallfiles",
+  :description => "Use a smaller initial file size and maximum size"

--- a/recipes/configserver.rb
+++ b/recipes/configserver.rb
@@ -35,4 +35,7 @@ mongodb_instance "configserver" do
   logpath      node['mongodb']['logpath']
   dbpath       node['mongodb']['dbpath']
   enable_rest  node['mongodb']['enable_rest']
+  enable_directoryperdb node['mongodb']['enable_directoryperdb']
+  enable_noprealloc node['mongodb']['enable_noprealloc']
+  enable_smallfiles node['mongodb']['enable_smallfiles']
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,5 +42,8 @@ if node.recipe?("mongodb::default") or node.recipe?("mongodb")
     logpath      node['mongodb']['logpath']
     dbpath       node['mongodb']['dbpath']
     enable_rest  node['mongodb']['enable_rest']
+    enable_directoryperdb node['mongodb']['enable_directoryperdb']
+    enable_noprealloc node['mongodb']['enable_noprealloc']
+    enable_smallfiles node['mongodb']['enable_smallfiles']
   end
 end

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -44,4 +44,7 @@ mongodb_instance "mongos" do
   dbpath       node['mongodb']['dbpath']
   configserver configsrv
   enable_rest  node['mongodb']['enable_rest']
+  enable_directoryperdb node['mongodb']['enable_directoryperdb']
+  enable_noprealloc node['mongodb']['enable_noprealloc']
+  enable_smallfiles node['mongodb']['enable_smallfiles']
 end

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -28,5 +28,8 @@ if !node.recipe?("mongodb::shard")
     dbpath       node['mongodb']['dbpath']
     replicaset   node
     enable_rest  node['mongodb']['enable_rest']
+    enable_directoryperdb node['mongodb']['enable_directoryperdb']
+    enable_noprealloc node['mongodb']['enable_noprealloc']
+    enable_smallfiles node['mongodb']['enable_smallfiles']
   end
 end

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -42,4 +42,7 @@ mongodb_instance "shard" do
     replicaset    node
   end
   enable_rest node['mongodb']['enable_rest']
+  enable_directoryperdb node['mongodb']['enable_directoryperdb']
+  enable_noprealloc node['mongodb']['enable_noprealloc']
+  enable_smallfiles node['mongodb']['enable_smallfiles']
 end

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -31,3 +31,15 @@ DAEMON_OPTS="$DAEMON_OPTS --rest"
 DAEMON_OPTS="$DAEMON_OPTS --fork"
 DBPATH="<%= @dbpath %>"
 <% end -%>
+
+<% if @enable_directoryperdb %>
+DAEMON_OPTS="$DAEMON_OPTS --directoryperdb"
+<% end %>
+
+<% if @enable_noprealloc %>
+DAEMON_OPTS="$DAEMON_OPTS --noprealloc"
+<% end %>
+
+<% if @enable_smallfiles %>
+DAEMON_OPTS="$DAEMON_OPTS --smallfiles"
+<% end %>

--- a/templates/freebsd/mongodb.default.erb
+++ b/templates/freebsd/mongodb.default.erb
@@ -24,4 +24,16 @@ DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% end %>
 
+<% if @enable_directoryperdb %>
+DAEMON_OPTS="$DAEMON_OPTS --directoryperdb"
+<% end %>
+
+<% if @enable_noprealloc %>
+DAEMON_OPTS="$DAEMON_OPTS --noprealloc"
+<% end %>
+
+<% if @enable_smallfiles %>
+DAEMON_OPTS="$DAEMON_OPTS --smallfiles"
+<% end %>
+
 <%= @name %>_command_args="$DAEMON_OPTS"


### PR DESCRIPTION
This patch adds attributes to apply the `--directoryperdb`, `--noprealloc` and `--smallfiles` command line flags.

I have kept with existing style, but clearly this approach won't look very pretty if we intend to support everything on http://www.mongodb.org/display/DOCS/Command+Line+Parameters.
