### PR TITLE
Adding 'bind_ip' as optional parameter

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 
 default[:mongodb][:dbpath] = "/var/lib/mongodb"
 default[:mongodb][:logpath] = "/var/log/mongodb"
+default[:mongodb][:bind_ip] = node[:ipaddress]
 default[:mongodb][:port] = 27017
 
 # cluster identifier

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 
 default[:mongodb][:dbpath] = "/var/lib/mongodb"
 default[:mongodb][:logpath] = "/var/log/mongodb"
-default[:mongodb][:bind_ip] = node[:ipaddress]
+default[:mongodb][:bind_ip] = nil
 default[:mongodb][:port] = 27017
 
 # cluster identifier

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -19,10 +19,10 @@
 # limitations under the License.
 #
 
-define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start], :port => 27017 , \
-    :logpath => "/var/log/mongodb", :dbpath => "/data", :configfile => "/etc/mongodb.conf", \
-    :configserver => [], :replicaset => nil, :enable_rest => false, \
-    :notifies => [] do
+define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start],
+    :bind_ip => "0.0.0.0", :port => 27017 , :logpath => "/var/log/mongodb",
+    :dbpath => "/data", :configfile => "/etc/mongodb.conf", :configserver => [],
+    :replicaset => nil, :enable_rest => false, :notifies => [] do
     
   include_recipe "mongodb::default"
   
@@ -31,6 +31,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   service_action = params[:action]
   service_notifies = params[:notifies]
   
+  bind_ip = params[:bind_ip]
   port = params[:port]
 
   logpath = params[:logpath]
@@ -94,6 +95,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       "name" => name,
       "config" => configfile,
       "configdb" => configserver,
+      "bind_ip" => bind_ip,
       "port" => port,
       "logpath" => logfile,
       "dbpath" => dbpath,

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -20,7 +20,7 @@
 #
 
 define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start],
-    :bind_ip => "0.0.0.0", :port => 27017 , :logpath => "/var/log/mongodb",
+    :bind_ip => nil, :port => 27017 , :logpath => "/var/log/mongodb",
     :dbpath => "/data", :configfile => "/etc/mongodb.conf", :configserver => [],
     :replicaset => nil, :enable_rest => false, :notifies => [] do
     

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ maintainer        "edelight GmbH"
 maintainer_email  "markus.korn@edelight.de"
 license           "Apache 2.0"
 description       "Installs and configures mongodb"
-version           "0.11"
+version           "0.12"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"

--- a/metadata.rb
+++ b/metadata.rb
@@ -60,3 +60,8 @@ attribute "mongodb/replicaset_name",
 attribute "mongodb/enable_rest",
   :display_name => "Enable Rest",
   :description => "Enable the ReST interface of the webserver"
+
+attribute "mongodb/bin_ip",
+  :display_name => "Bind address",
+  :description => "MongoDB instance bind address",
+  :default => nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -61,7 +61,7 @@ attribute "mongodb/enable_rest",
   :display_name => "Enable Rest",
   :description => "Enable the ReST interface of the webserver"
 
-attribute "mongodb/bin_ip",
+attribute "mongodb/bind_ip",
   :display_name => "Bind address",
   :description => "MongoDB instance bind address",
   :default => nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,7 @@ if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
   # configure default instance
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
+    bind_ip      node['mongodb']['bind_ip']
     port         node['mongodb']['port']
     logpath      node['mongodb']['logpath']
     dbpath       node['mongodb']['dbpath']

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -6,6 +6,7 @@ NAME="<%= @name %>"
 
 DAEMON_OPTS=""
 
+<%= @bind_ip ? "DAEMON_OPTS=\"$DAEMON_OPTS --bind_ip #{@bind_ip}\"" : "" %>
 <%= @port ? "DAEMON_OPTS=\"$DAEMON_OPTS --port #{@port}\"" : "" %>
 <%= @dbpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --dbpath #{@dbpath}\"" : "" %>
 <%= @logpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --logpath #{@logpath}\"" : "" %>

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -6,7 +6,9 @@ NAME="<%= @name %>"
 
 DAEMON_OPTS=""
 
-<%= @bind_ip ? "DAEMON_OPTS=\"$DAEMON_OPTS --bind_ip #{@bind_ip}\"" : "" %>
+<% if @bind_ip -%>
+DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
+<% end -%>
 <%= @port ? "DAEMON_OPTS=\"$DAEMON_OPTS --port #{@port}\"" : "" %>
 <%= @dbpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --dbpath #{@dbpath}\"" : "" %>
 <%= @logpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --logpath #{@logpath}\"" : "" %>

--- a/templates/freebsd/mongodb.default.erb
+++ b/templates/freebsd/mongodb.default.erb
@@ -3,6 +3,9 @@
 
 DAEMON_OPTS="--fork"
 
+<% if @bind_ip -%>
+DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
+<% end -%>
 <%= @port ? "DAEMON_OPTS=\"$DAEMON_OPTS --port #{@port}\"" : "" %>
 <%= @dbpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --dbpath #{@dbpath}\"" : "" %>
 <%= @logpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --logpath #{@logpath}\"" : "" %>


### PR DESCRIPTION
Adding 'bind_ip' parameter and bumping version to '0.12'. As discussed at #18 'bind_ip' should not be managed by default, doing it only when 'bind_ip' parameter is explicitly set.

This pull request includes previous Mike Dolphs pull request  User@SHA ref: fooforge/chef-cookbooks@291c5abe8e0394086fdce7b8838cff0ad6161360 commit.
