### PR TITLE
Update Ubuntu keyserver URL to work behind firewalls

### DIFF
--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -33,7 +33,7 @@ when "debian", "ubuntu"
     uri "http://downloads-distro.mongodb.org/repo/debian-sysvinit"
     distribution "dist"
     components ["10gen"]
-    keyserver "keyserver.ubuntu.com"
+    keyserver "hkp://keyserver.ubuntu.com:80"
     key "7F0CEB10"
     action :add
     notifies :run, "execute[apt-get update]", :immediately


### PR DESCRIPTION
See http://ubuntuforums.org/archive/index.php/t-1292637.html for more information on the keyserver URL choice.
