### PR TITLE
Fix timing bug in Mongodb replicaset configuration

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -135,7 +135,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     variables :provides => name
     notifies :restart, "service[#{name}]"
   end
-  
+
   # service
   service name do
     supports :status => true, :restart => true

--- a/templates/default/mongodb.init.erb
+++ b/templates/default/mongodb.init.erb
@@ -92,7 +92,12 @@ running() {
     [ ! -f "$PIDFILE" ] && return 1
     pid=`cat $PIDFILE`
     running_pid $pid $DAEMON || return 1
-    return 0
+    for i in `seq 1 20`; do
+      nc -z localhost <%= node['mongodb']['port'] %> && return 0
+      echo -n "."
+      sleep 15
+    done
+    return 1
 }
 
 start_server() {


### PR DESCRIPTION
Since start_server() and restart_server() do not actually verify whether the
port is open and receiving connections (even though mongo starts up,
pre-alloc/other setup takes a few minutes), the replicaset recipe was failing to
establish a connection with the db.  The change to the initd file waits for the
port to be open before proceeding, ensuring that the replicaset recipe will
work.

Fixes #17
