### PR TITLE
Fix mongodb replicaset recipe to include node establishing set

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -44,12 +44,15 @@ class Chef::ResourceDefinitionList::MongoDB
       return
     end
     
+    # Want the node originating the connection to be included in the replicaset
+    members << node unless members.include?(node)
     members.sort!{ |x,y| x.name <=> y.name }
     rs_members = []
     members.each_index do |n|
       port = members[n]['mongodb']['port']
       rs_members << {"_id" => n, "host" => "#{members[n]['fqdn']}:#{port}"}
     end
+
     
     Chef::Log.info(
       "Configuring replicaset with members #{members.collect{ |n| n['hostname'] }.join(', ')}"


### PR DESCRIPTION
Mongodb complained when the node attempted to initiate a replicaset connection
because the node had not included itself among the replicaset members.  This
occurs because the mongodb definition creates the members array by doing a
knife search on all nodes with a matching the replicaset name, but since the
chef-run is not completed at that point, the current node is not included.
