### PR TITLE
Defaults template is broken on Debian-based platforms.

### DIFF
--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -24,7 +24,7 @@ DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% end %>
 
-<% if node.platform?("centos","redhat","fedora","amazon") -%>
+<% if %w("centos","redhat","fedora","amazon").include? node.platform -%>
 DAEMON_OPTS="$DAEMON_OPTS --fork"
 DBPATH="<%= @dbpath %>"
 <% end -%>

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -24,7 +24,7 @@ DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% end %>
 
-<% if %w("centos","redhat","fedora","amazon").include? node.platform -%>
+<% if %w(centos redhat fedora amazon).include? node.platform -%>
 DAEMON_OPTS="$DAEMON_OPTS --fork"
 DBPATH="<%= @dbpath %>"
 <% end -%>


### PR DESCRIPTION
This code:

<% if node.platform?("centos","redhat","fedora","amazon") -%>
    DAEMON_OPTS="$DAEMON_OPTS --fork"
    DBPATH="<%= @dbpath %>"
<% end -%>
Does not work as intended; the node.platform? call returns true always. This causes --fork to be added to the options on Debian and Ubuntu, which breaks the init script.
