### PR TITLE
Updated for Ubuntu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,44 @@ default[:mongodb][:dbpath] = "/var/lib/mongodb"
 default[:mongodb][:logpath] = "/var/log/mongodb"
 default[:mongodb][:port] = 27017
 
-# roles
+# cluster identifier
 default[:mongodb][:client_roles] = []
 default[:mongodb][:cluster_name] = nil
+default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
+
+default[:mongodb][:enable_rest] = false
+
+default[:mongodb][:user] = "mongodb"
+default[:mongodb][:group] = "mongodb"
+default[:mongodb][:root_group] = "root"
+
+default[:mongodb][:init_dir] = "/etc/init.d"
+
+default[:mongodb][:init_script_template] = "mongodb.init.erb"
+
+case node['platform']
+when "freebsd"
+  default[:mongodb][:defaults_dir] = "/etc/rc.conf.d"
+  default[:mongodb][:init_dir] = "/usr/local/etc/rc.d"
+  default[:mongodb][:root_group] = "wheel"
+  default[:mongodb][:package_name] = "mongodb"
+
+when "centos","redhat","fedora","amazon"
+  default[:mongodb][:defaults_dir] = "/etc/sysconfig"
+  default[:mongodb][:package_name] = "mongo-10gen-server"
+  default[:mongodb][:user] = "mongod"
+  default[:mongodb][:group] = "mongod"
+  default[:mongodb][:init_script_template] = "redhat-mongodb.init.erb"
+
+when "ubuntu"
+  default[:mongodb][:defaults_dir] = "/etc/default"
+  default[:mongodb][:root_group] = "root"
+  default[:mongodb][:package_name] = "mongodb"
+
+else
+  default[:mongodb][:defaults_dir] = "/etc/default"
+  default[:mongodb][:root_group] = "root"
+  default[:mongodb][:package_name] = "mongodb-10gen"
+
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,39 +21,7 @@ default[:mongodb][:dbpath] = "/var/lib/mongodb"
 default[:mongodb][:logpath] = "/var/log/mongodb"
 default[:mongodb][:port] = 27017
 
-# cluster identifier
+# roles
 default[:mongodb][:client_roles] = []
 default[:mongodb][:cluster_name] = nil
-default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
-
-default[:mongodb][:enable_rest] = false
-
-default[:mongodb][:user] = "mongodb"
-default[:mongodb][:group] = "mongodb"
-default[:mongodb][:root_group] = "root"
-
-default[:mongodb][:init_dir] = "/etc/init.d"
-
-default[:mongodb][:init_script_template] = "mongodb.init.erb"
-
-case node['platform']
-when "freebsd"
-  default[:mongodb][:defaults_dir] = "/etc/rc.conf.d"
-  default[:mongodb][:init_dir] = "/usr/local/etc/rc.d"
-  default[:mongodb][:root_group] = "wheel"
-  default[:mongodb][:package_name] = "mongodb"
-
-when "centos","redhat","fedora","amazon"
-  default[:mongodb][:defaults_dir] = "/etc/sysconfig"
-  default[:mongodb][:package_name] = "mongo-10gen-server"
-  default[:mongodb][:user] = "mongod"
-  default[:mongodb][:group] = "mongod"
-  default[:mongodb][:init_script_template] = "redhat-mongodb.init.erb"
-
-else
-  default[:mongodb][:defaults_dir] = "/etc/default"
-  default[:mongodb][:root_group] = "root"
-  default[:mongodb][:package_name] = "mongodb-10gen"
-
-end

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -21,7 +21,8 @@
 
 define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :start], :port => 27017 , \
     :logpath => "/var/log/mongodb", :dbpath => "/data", :configfile => "/etc/mongodb.conf", \
-    :configserver => [], :replicaset => nil, :notifies => [] do
+    :configserver => [], :replicaset => nil, :enable_rest => false, \
+    :notifies => [] do
     
   include_recipe "mongodb::default"
   
@@ -41,10 +42,28 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   configserver_nodes = params[:configserver]
   
   replicaset = params[:replicaset]
-  begin
-    replicaset_name = "rs_#{replicaset['mongodb']['shard_name']}" # Looks weird, but we need just some name
-  rescue
-    replicaset_name = nil
+  if type == "shard"
+    if replicaset.nil?
+      replicaset_name = nil
+    else
+      # for replicated shards we autogenerate the replicaset name for each shard
+      replicaset_name = "rs_#{replicaset['mongodb']['shard_name']}"
+    end
+  else
+    # if there is a predefined replicaset name we use it,
+    # otherwise we try to generate one using 'rs_$SHARD_NAME'
+    begin
+      replicaset_name = replicaset['mongodb']['replicaset_name']
+    rescue
+      replicaset_name = nil
+    end
+    if replicaset_name.nil?
+      begin
+        replicaset_name = "rs_#{replicaset['mongodb']['shard_name']}"
+      rescue
+        replicaset_name = nil
+      end
+    end
   end
   
   if !["mongod", "shard", "configserver", "mongos"].include?(type)
@@ -64,10 +83,10 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   end
   
   # default file
-  template "/etc/default/#{name}" do
+  template "#{node['mongodb']['defaults_dir']}/#{name}" do
     action :create
     source "mongodb.default.erb"
-    group "root"
+    group node['mongodb']['root_group']
     owner "root"
     mode "0644"
     variables(
@@ -80,37 +99,41 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       "dbpath" => dbpath,
       "replicaset_name" => replicaset_name,
       "configsrv" => false, #type == "configserver", this might change the port
-      "shardsrv" => false  #type == "shard", dito.
+      "shardsrv" => false,  #type == "shard", dito.
+      "enable_rest" => params[:enable_rest]
     )
     notifies :restart, "service[#{name}]"
   end
   
   # log dir [make sure it exists]
   directory logpath do
-    owner "mongodb"
-    group "mongodb"
+    owner node[:mongodb][:user]
+    group node[:mongodb][:group]
     mode "0755"
     action :create
+    recursive true
   end
   
   if type != "mongos"
     # dbpath dir [make sure it exists]
     directory dbpath do
-      owner "mongodb"
-      group "mongodb"
+      owner node[:mongodb][:user]
+      group node[:mongodb][:group]
       mode "0755"
       action :create
+      recursive true
     end
   end
   
-  unless node[:platform] == 'ubuntu' 
-    # init script
-    cookbook_file "/etc/init.d/#{name}" do
+  # init script
+  unless node[:platform] == 'ubuntu'
+    template "#{node['mongodb']['init_dir']}/#{name}" do
       action :create
-      source "mongodb.init"
-      group "root"
+      source node[:mongodb][:init_script_template]
+      group node['mongodb']['root_group']
       owner "root"
       mode "0755"
+      variables :provides => name
       notifies :restart, "service[#{name}]"
     end
   end
@@ -131,7 +154,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       notifies :create, "ruby_block[config_replicaset]"
     end
     if type == "mongos"
-      notifies :create, "ruby_block[config_sharding]"
+      notifies :create, "ruby_block[config_sharding]", :immediately
     end
     if name == "mongodb"
       # we don't care about a running mongodb service in these cases, all we need is stopping it


### PR DESCRIPTION
Made some updates to work with ubuntu

1)  I updated the attribute so for ubuntu it uses the mongodb package (mongodb-10gen failed)
2) updated the definition to use different start/stop/restart commands for the service (without them the recipe fails)
3) prevented the init.d script from getting created (recipe works fine without this but when ubuntu restarts it gives an error saying mongodb is already running).
