### PR TITLE
10gen repo URL

### DIFF
--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -42,7 +42,7 @@ when "debian", "ubuntu"
 when "centos","redhat","fedora","amazon"
   yum_repository "10gen" do
     description "10gen RPM Repository"
-    url "http://downloads-distro.mongodb.org/repo/redhat/os/$arch"
+    url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
     action :add
   end
 


### PR DESCRIPTION
On RedHat machines the 10gen RPM repository URL is configured to be `http://downloads-distro.mongodb.org/repo/redhat/os/$arch`. I have some Intel machines where $arch is resolved to `ia32e` instead of `x86_64`. This can be fixed by using the `$basearch` placeholder instead of `$arch`. See https://access.redhat.com/knowledge/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html for details.
