### PR TITLE
add mongodb/reload_action attribute to enable config changes without a restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ For examples see the USAGE section below.
 
 # ATTRIBUTES:
 
+* `mongodb[:reload_action]` - Action to take when MongoDB conf files are
+    modified, default is `"restart"`
 * `mongodb[:dbpath]` - Location for mongodb data directory, defaults to "/var/lib/mongodb"
 * `mongodb[:logpath]` - Path for the logfiles, default is "/var/log/mongodb"
 * `mongodb[:port]` - Port the mongod listens on, default is 27017

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,8 @@ default[:mongodb][:is_replicaset] = nil
 default[:mongodb][:is_shard] = nil
 default[:mongodb][:is_configserver] = nil
 
+default[:mongodb][:reload_action] = "restart" # or "nothing"
+
 case node['platform_family']
 when "freebsd"
   default[:mongodb][:package_name] = "mongo-10gen-server"

--- a/metadata.rb
+++ b/metadata.rb
@@ -37,6 +37,11 @@ attribute "mongodb/port",
   :description => "Port the mongodb instance is running on",
   :default => "27017"
 
+attribute "mongodb/reload_action",
+  :display_name => "MongoDB conf file reload action",
+  :description => "Action to take when MongoDB conf files are modified",
+  :default => "restart"
+
 attribute "mongodb/client_roles",
   :display_name => "Client Roles",
   :description => "Roles of nodes who need access to the mongodb instance",


### PR DESCRIPTION
This is my response to https://github.com/edelight/chef-mongodb/issues/55 and https://github.com/edelight/chef-mongodb/pull/36. It's a little misleadingly named since mongodb has no ability actually reload configs, but it is named that way for consistency with other cookbooks (and a hope that someday mongodb will have reloads).
