### PR TITLE
do not log an unavoidable warning

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -74,7 +74,6 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     daemon = "/usr/bin/mongod"
     configserver = nil
     configfile = nil
-    Chef::Log.warn("We are not using a configfile, as the daemons can be configured via commandline")
   else
     daemon = "/usr/bin/mongos"
     configfile = nil


### PR DESCRIPTION
For all instance types except for "mongos" an unavoidable warning is logged. This should be avoided to reduce confusion. I changed the log level to debug.
