### PR TITLE
Use default "mongod" instance name when running standalone

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,7 @@ when "freebsd"
   default[:mongodb][:init_dir] = "/usr/local/etc/rc.d"
   default[:mongodb][:root_group] = "wheel"
   default[:mongodb][:package_name] = "mongodb"
+  default[:mongodb][:instance_name] = "mongodb"
 
 when "centos","redhat","fedora","amazon","scientific"
   default[:mongodb][:defaults_dir] = "/etc/sysconfig"
@@ -51,11 +52,13 @@ when "centos","redhat","fedora","amazon","scientific"
   default[:mongodb][:user] = "mongod"
   default[:mongodb][:group] = "mongod"
   default[:mongodb][:init_script_template] = "redhat-mongodb.init.erb"
+  default[:mongodb][:instance_name] = "mongod"
 
 else
   default[:mongodb][:defaults_dir] = "/etc/default"
   default[:mongodb][:root_group] = "root"
   default[:mongodb][:package_name] = "mongodb-10gen"
   default[:mongodb][:apt_repo] = "debian-sysvinit"
+  default[:mongodb][:instance_name] = "mongodb"
 
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,7 +35,15 @@ end
 
 if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
   # configure default instance
-  mongodb_instance "mongodb" do
+
+  name = case node['platform']
+         when "centos", "redhat", "fedora", "amazon", "scientific"
+           "mongod"
+         when "ubuntu", "debian", "freebsd"
+           "mongodb"
+         end
+
+  mongodb_instance name do
     mongodb_type "mongod"
     bind_ip      node['mongodb']['bind_ip']
     port         node['mongodb']['port']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,14 +36,7 @@ end
 if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
   # configure default instance
 
-  name = case node['platform']
-         when "centos", "redhat", "fedora", "amazon", "scientific"
-           "mongod"
-         when "ubuntu", "debian", "freebsd"
-           "mongodb"
-         end
-
-  mongodb_instance name do
+  mongodb_instance node['mongodb']['instance_name'] do
     mongodb_type "mongod"
     bind_ip      node['mongodb']['bind_ip']
     port         node['mongodb']['port']

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -21,7 +21,7 @@ include_recipe "mongodb"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe
 if !node.recipes.include?("mongodb::shard")
-  mongodb_instance "mongodb" do
+  mongodb_instance node['mongodb']['instance_name'] do
     mongodb_type "mongod"
     port         node['mongodb']['port']
     logpath      node['mongodb']['logpath']


### PR DESCRIPTION
When running standalone, just re-use that name rather than creating one called "mongodb". Otherwise, you wind up with /etc/sysconfig/mongod and mongodb, two sets of init scripts, two sets of logs in /var/log/mongod, etc.
