### PR TITLE
Fix checks for included recipes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ package node[:mongodb][:package_name] do
   action :install
 end
 
-needs_mongo_gem = (node.recipes.include?("mongodb::replicaset") or node.recipes.include?("mongodb::mongos"))
+needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))
 
 if needs_mongo_gem
   # install the mongo ruby gem at compile time to make it globally available
@@ -33,7 +33,7 @@ if needs_mongo_gem
   Gem.clear_paths
 end
 
-if node.recipes.include?("mongodb::default") or node.recipes.include?("mongodb")
+if node.recipe?("mongodb::default") or node.recipe?("mongodb")
   # configure default instance
   mongodb_instance "mongodb" do
     mongodb_type "mongod"

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -20,7 +20,7 @@
 include_recipe "mongodb"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe
-if !node.recipes.include?("mongodb::shard")
+if !node.recipe?("mongodb::shard")
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
     port         node['mongodb']['port']

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -27,7 +27,7 @@ service "mongodb" do
   action [:disable, :stop]
 end
 
-is_replicated = node.recipes.include?("mongodb::replicaset")
+is_replicated = node.recipe?("mongodb::replicaset")
 
 
 # we are not starting the shard service with the --shardsvr


### PR DESCRIPTION
When using `include_recipe` inside authors own recipe, the checks for included recipes don't detect them. This fixes the issue by using `node.recipe?` instead of `node.recipes.include?`.

Not sure why this was not preferred option, but could it be because of [this](http://tickets.opscode.com/browse/CHEF-1587)?
