### PR TITLE
adds name "mongodb" to metadata, very useful when working with Berkshelf

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name              "mongodb"
 maintainer        "edelight GmbH"
 maintainer_email  "markus.korn@edelight.de"
 license           "Apache 2.0"


### PR DESCRIPTION
I'm working with [Berkshelf](http://berkshelf.com) to manage my cookbooks.
When cookbook without `name` is uploaded by berkshelf, it uses folder name as cookbook name, so `mongodb` becomes `chef-mongodb`
