### PR TITLE
adds oplog_size attribute for setting mongod daemon oplogSize parameter

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,14 @@ default[:mongodb][:init_dir] = "/etc/init.d"
 
 default[:mongodb][:init_script_template] = "mongodb.init.erb"
 
+#  oplog_size 
+#
+# Specifies a maximum size in megabytes for the replication operation log (e.g. oplog.) 
+# By mongod creates an oplog based on the maximum amount of space available. 
+# For 64-bit systems, the op log is typically 5% of available disk space.
+
+default[:mongodb][:oplog_size] = nil
+
 case node['platform']
 when "freebsd"
   default[:mongodb][:defaults_dir] = "/etc/rc.conf.d"

--- a/metadata.rb
+++ b/metadata.rb
@@ -66,3 +66,8 @@ attribute "mongodb/bind_ip",
   :display_name => "Bind address",
   :description => "MongoDB instance bind address",
   :default => nil
+
+attribute "mongodb/oplog_size",
+  :display_name => "oplogSize",
+  :description => "Specifies a maximum size in megabytes for the replication operation log",
+  :default => nil

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -23,6 +23,10 @@ DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
 DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 <% end %>
 
+<% if node[:mongodb][:oplog_size] %>
+DAEMON_OPTS="$DAEMON_OPTS --oplogSize <%= node[:mongodb][:oplog_size] %>"
+<% end %>
+
 <% if @enable_rest %>
 DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% end %>

--- a/templates/freebsd/mongodb.default.erb
+++ b/templates/freebsd/mongodb.default.erb
@@ -20,6 +20,10 @@ DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
 DAEMON_OPTS="$DAEMON_OPTS --replSet <%= @replicaset_name %>"
 <% end %>
 
+<% if node[:mongodb][:oplog_size] %>
+DAEMON_OPTS="$DAEMON_OPTS --oplogSize <%= node[:mongodb][:oplog_size] %>"
+<% end %>
+
 <% if @enable_rest %>
 DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% end %>


### PR DESCRIPTION
It will be a grate addition for mongodb replica set users such as myself to have the option to set oplogSize manually.
By default it's 5% of available disk space.
