### PR TITLE
extracts mongodb package and mongo gem install code into mongodb::base recipe and related changes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,6 +38,10 @@ default[:mongodb][:init_dir] = "/etc/init.d"
 
 default[:mongodb][:init_script_template] = "mongodb.init.erb"
 
+default[:mongodb][:is_replicaset] = nil
+default[:mongodb][:is_shard] = nil
+default[:mongodb][:is_configserver] = nil
+
 case node['platform']
 when "freebsd"
   default[:mongodb][:defaults_dir] = "/etc/rc.conf.d"

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -182,7 +182,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     shard_nodes = search(
       :node,
       "mongodb_cluster_name:#{node['mongodb']['cluster_name']} AND \
-       recipes:mongodb\\:\\:shard AND \
+       mongodb_is_shard:true AND \
        chef_environment:#{node.chef_environment}"
     )
     

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -159,7 +159,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     rs_nodes = search(
       :node,
       "mongodb_cluster_name:#{replicaset['mongodb']['cluster_name']} AND \
-       recipes:mongodb\\:\\:replicaset AND \
+       mongodb_is_replicaset:true AND \
        mongodb_shard_name:#{replicaset['mongodb']['shard_name']} AND \
        chef_environment:#{replicaset.chef_environment}"
     )

--- a/recipes/base.rb
+++ b/recipes/base.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: mongodb
-# Recipe:: default
+# Recipe:: base
 #
 # Copyright 2011, edelight GmbH
 # Authors:
@@ -19,14 +19,16 @@
 # limitations under the License.
 #
 
-include_recipe "mongodb::base"
+package node[:mongodb][:package_name] do
+  action :install
+end
 
-# configure default instance
-mongodb_instance "mongodb" do
-  mongodb_type "mongod"
-  bind_ip      node['mongodb']['bind_ip']
-  port         node['mongodb']['port']
-  logpath      node['mongodb']['logpath']
-  dbpath       node['mongodb']['dbpath']
-  enable_rest  node['mongodb']['enable_rest']
+needs_mongo_gem = (node.mongodb.is_replicaset or node.mongodb.is_shard)
+
+if needs_mongo_gem
+  # install the mongo ruby gem at compile time to make it globally available
+  gem_package 'mongo' do
+    action :nothing
+  end.run_action(:install)
+  Gem.clear_paths
 end

--- a/recipes/configserver.rb
+++ b/recipes/configserver.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-include_recipe "mongodb"
+include_recipe "mongodb::base"
 
 service "mongodb" do
   supports :status => true, :restart => true

--- a/recipes/configserver.rb
+++ b/recipes/configserver.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+node.set[:mongodb][:is_configserver] = true
+
 include_recipe "mongodb::base"
 
 service "mongodb" do

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-include_recipe "mongodb"
+include_recipe "mongodb::base"
 
 service "mongodb" do
   action [:disable, :stop]

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -28,7 +28,7 @@ end
 configsrv = search(
   :node,
   "mongodb_cluster_name:#{node['mongodb']['cluster_name']} AND \
-   recipes:mongodb\\:\\:configserver AND \
+   mongodb_is_configserver:true AND \
    chef_environment:#{node.chef_environment}"
 )
 

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+node.set[:mongodb][:is_replicaset] = true
+
 include_recipe "mongodb::base"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -22,7 +22,7 @@ node.set[:mongodb][:is_replicaset] = true
 include_recipe "mongodb::base"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe
-if !node.recipe?("mongodb::shard")
+if !node.mongodb.is_shard
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
     port         node['mongodb']['port']

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "mongodb"
+include_recipe "mongodb::base"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe
 if !node.recipe?("mongodb::shard")

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -29,9 +29,6 @@ service "mongodb" do
   action [:disable, :stop]
 end
 
-is_replicated = node.recipe?("mongodb::replicaset")
-
-
 # we are not starting the shard service with the --shardsvr
 # commandline option because right now this only changes the port it's
 # running on, and we are overwriting this port anyway.
@@ -40,7 +37,7 @@ mongodb_instance "shard" do
   port         node['mongodb']['port']
   logpath      node['mongodb']['logpath']
   dbpath       node['mongodb']['dbpath']
-  if is_replicated
+  if node.mongodb.is_replicaset 
     replicaset    node
   end
   enable_rest node['mongodb']['enable_rest']

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-include_recipe "mongodb::default"
+include_recipe "mongodb::base"
 
 # disable and stop the default mongodb instance
 service "mongodb" do

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+node.set[:mongodb][:is_shard] = true
+
 include_recipe "mongodb::base"
 
 # disable and stop the default mongodb instance


### PR DESCRIPTION
The story of this pull request starts with me using cookbook to define nodes run lists instead on run_list or role, it really makes things simpler for me.

So I created a cookbook that includes the following code:

``` ruby
include_recipe "mongodb::10gen_repo"
include_recipe "mongodb"
```

I bootstrap a node with my cookbook and see that 10gen package wasn't installed.
After some digging I understood that the following line in `mongodb::default` recipe is causing
this issue:

``` ruby
if node.recipe?("mongodb::default") or node.recipe?("mongodb")
```

I asked myself why this validation is required and the answer was cause of the following code in `mongodb::default` :

``` ruby
package node[:mongodb][:package_name] do
  action :install
end

needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))

if needs_mongo_gem
  # install the mongo ruby gem at compile time to make it globally available
  gem_package 'mongo' do
    action :nothing
  end.run_action(:install)
  Gem.clear_paths
end
```

So I moved this code to `mongodb::base` recipe and removed the validation,
and Ding! Everything works :)

I did a further digging and saw other code the validated cookbook inclusion and decided to refactor it a bit.
The result is this pull request, will be really glad it will be accepted, has many others on the way ;)
