### PR TITLE
adds aws_ebs_volume recipe for creating EBS volume on EC2 instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Installs and configures MongoDB, supporting:
 * Sharding
 * Replication and Sharding
 * 10gen repository package installation
+* AWS EBS volume 
 
 # REQUIREMENTS:
 
@@ -38,6 +39,11 @@ For examples see the USAGE section below.
 * `mongodb[:shard_name]` - Name of a shard, default is "default"
 * `mongodb[:sharded_collections]` - Define which collections are sharded
 * `mongodb[:replicaset_name]` - Define name of replicatset
+* `mongodb[:ec2][:volume_size]` - Size in GB of EBS volume, default is 50
+* `mongodb[:ec2][:volume_connection]` - Name of EBS volume connection, default is sdf
+* `mongodb[:ec2][:volume_path]` - Path to mount EBS volume and DB data store,
+  default is /data/db. 
+  `recipe[mongodb::aws_ebs_volume]` Sets `mongodb[:dbpath]` same as `mongodb[:ec2][:volume_path]`
 
 # USAGE:
 
@@ -48,6 +54,14 @@ corresponding platform. Currently only implemented for the Debian and Ubuntu rep
 
 Usage: just add `recipe[mongodb::10gen_repo]` to the node run_list *before* any other
 MongoDB recipe, and the mongodb-10gen **stable** packages will be installed instead of the distribution default.
+
+## EBS Volume 
+
+Creates EBS volume and mounts it to EC2 instance for DB data storage, following 
+[Amazon Instructions](http://media.amazonwebservices.com/AWS_NoSQL_MongoDB.pdf)
+
+Usage: just add `recipe[mongodb::aws_ebs_volume]` to the node run_list *before* any other
+MongoDB recipe, except `recipe[mongodb::10gen_repo]`.
 
 ## Single mongodb instance
 

--- a/attributes/aws_ebs_volume.rb
+++ b/attributes/aws_ebs_volume.rb
@@ -1,0 +1,3 @@
+default[:mongodb][:ebs][:volume_size] = 50
+default[:mongodb][:ebs][:volume_path] = "/data/db"
+default[:mongodb][:ebs][:volume_connection] = "sdf"

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ version           "0.12"
 
 recipe "mongodb", "Installs and configures a single node mongodb instance"
 recipe "mongodb::10gen_repo", "Adds the 10gen repo to get the latest packages"
+recipe "mongodb::aws_ebs_volume", "Creates EBS volume on Amazon EC2 instance for data / logs storage"
 recipe "mongodb::mongos", "Installs and configures a mongos which can be used in a sharded setup"
 recipe "mongodb::configserver", "Installs and configures a configserver for mongodb sharding"
 recipe "mongodb::shard", "Installs and configures a single shard"
@@ -14,6 +15,7 @@ recipe "mongodb::replicaset", "Installs and configures a mongodb replicaset"
 
 depends "apt"
 depends "yum"
+depends "aws"
 
 %w{ ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|
   supports os
@@ -67,3 +69,18 @@ attribute "mongodb/bind_ip",
   :display_name => "Bind address",
   :description => "MongoDB instance bind address",
   :default => nil
+
+attribute "mongodb/ebs/volume_size",
+  :display_name => "EBS Volume Size",
+  :description => "Size in GB of EBS volume",
+  :default => "50"
+
+attribute "mongodb/ebs/volume_connection",
+  :display_name => "EBS Volume Connection",
+  :description => "Name of EBS volume connection ",
+  :default => "sdf"
+
+attribute "mongodb/ebs/volume_path",
+  :display_name => "EBS Volume Path",
+  :description => "Path to mount EBS volume and DB data store",
+  :default => "/data/db"

--- a/recipes/aws_ebs_volume.rb
+++ b/recipes/aws_ebs_volume.rb
@@ -1,0 +1,93 @@
+#
+# Cookbook Name:: mongodb
+# Recipe:: aws_ebs_volume
+#
+# Copyright 2012, Applicaster LTD
+# Authors:
+#       Vitaly Gorodetsky <technical@applicaster.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+return unless node[:cloud] && node[:cloud][:provider] == "ec2"
+
+#For Xen native kernels (used by images such as Ubuntu (official) and Debian) 
+#the device is utilized by the kernel of the instance with "xvd" instead of "sd", 
+#e.g. attaching as /dev/sdk is accessible on the instance with /dev/xvdk.
+if node.filesystem.map { |a| a }.any? { |path| path[0] =~ /\/xv/ }
+  node.set[:mongodb][:ebs][:real_volume_connection] = node[:mongodb][:ebs][:volume_connection].gsub('sd','xvd')
+else
+  node.set[:mongodb][:ebs][:real_volume_connection] = node[:mongodb][:ebs][:volume_connection]
+end
+
+#Install right_aws gem
+include_recipe "aws"
+
+#Set mongodb db location same as attached ebs volume path
+node.set[:mongodb][:dbpath] = node[:mongodb][:ebs][:volume_path]
+#Set mongodb logs location to be stored on attached ebs volume
+node.set[:mongodb][:logpath] = "#{node[:mongodb][:ebs][:volume_path]}/logs"
+#Enable journaling
+node.set[:mongodb][:journal] = true
+
+#Load aws credentials from aws data bag
+begin
+  aws = data_bag_item("aws", "main")
+rescue
+  Chef::Log.fatal("Follow the instractions on http://community.opscode.com/cookbooks/aws to setup aws data bag")
+end
+
+#Create EBS Volume
+aws_ebs_volume "db_ebs_volume" do
+  aws_access_key aws['aws_access_key_id']
+  aws_secret_access_key aws['aws_secret_access_key']
+  size node[:mongodb][:ebs][:volume_size]
+  device "/dev/#{node[:mongodb][:ebs][:volume_connection]}"
+  action [ :create, :attach ]
+end
+
+#Format ebs volume as ext4
+bash "format_db_ebs_volume" do
+  user "root"
+  code <<-EOH
+  echo ",,L" | sfdisk /dev/#{node[:mongodb][:ebs][:real_volume_connection]}
+  echo "y" | mkfs -t ext4 /dev/#{node[:mongodb][:ebs][:real_volume_connection]}1
+  EOH
+  not_if {File.exists?(node[:mongodb][:ebs][:volume_path])}
+end
+
+#Create main folder 
+directory "#{node[:mongodb][:ebs][:volume_path]}" do
+  owner 'root'
+  group 'root'
+  action :create
+  recursive true
+end
+
+#Mount ebs volume
+bash "mount_db_ebs_volume" do
+  user "root"
+  code <<-EOH
+  echo `/dev/#{node[:mongodb][:ebs][:real_volume_connection]}1 #{node[:mongodb][:ebs][:volume_path]} auto noatime,noexec,nodiratime 0 0` >> /etc/fstab
+  mount -a /dev/#{node[:mongodb][:ebs][:real_volume_connection]}1 #{node[:mongodb][:ebs][:volume_path]}
+  EOH
+  not_if "df | grep #{node[:mongodb][:ebs][:real_volume_connection]}1"
+end
+
+#Create logs folder 
+directory "#{node[:mongodb][:ebs][:volume_path]}/logs" do
+  owner 'root'
+  group 'root'
+  action :create
+  recursive true
+end


### PR DESCRIPTION
We use Amazon EC2 as infrastructure for our mongo setup. 
Amazon has a really good [guide](http://media.amazonwebservices.com/AWS_NoSQL_MongoDB.pdf) for setting up mongos on EC2.
They strongly recommend to use separate EBS volume for DB data storage.
I created a recipe according to this guide, hope it will be useful not only for me :)
