### PR TITLE
increases nofile limit to 64000 for 'ubuntu' and 'debian' distros

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -196,5 +196,27 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       action :nothing
     end
   end
-end
 
+  if %w{ ubuntu debian }.include? node.platform  
+  
+    ruby_block "uncomment_pam_limits" do
+      block do
+        f = Chef::Util::FileEdit.new('/etc/pam.d/su')
+        f.search_file_replace(/^\#\s+(session\s+required\s+pam_limits.so)/, '\1')
+        f.write_file
+      end
+    end
+
+    ruby_block "update_nofile_limits" do
+      block do
+        f = Chef::Util::FileEdit.new('/etc/security/limits.conf')
+        f.insert_line_after_match(/^\#\*\s+hard/, '*                soft    nofile          64000')
+        f.insert_line_after_match(/^\#\*\s+hard/, '*                hard    nofile          64000')
+        f.write_file
+      end
+      not_if 'grep nofile /etc/security/limits.conf | grep hard'
+    end
+
+  end
+
+end


### PR DESCRIPTION
as [suggested by 10gen](http://docs.mongodb.org/manual/administration/ulimit/)

By default in `ubuntu` and `debian` distors the open files limit is set to 1024.
(Maybe in other distros also, could test only those two)

Without increasing the open files limit 10gen mms agent reports constant warning.
From 10gen [docs](http://mms.10gen.com/help/usage.html):

```
Note If you see a hostname in displayed in orange on the host page, this means that:
MMS has detected startup warnings for this host. You can see the warning in the last ping for the host.
MMS suspects that the host has a low ulimit setting that is less than 1024. MMS infers the host’s ulimit setting using the total number of available and current connections.
```
