### PR TITLE
Correct node-inclusion test

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -45,7 +45,7 @@ class Chef::ResourceDefinitionList::MongoDB
     end
     
     # Want the node originating the connection to be included in the replicaset
-    members << node unless members.include?(node)
+    members << node unless members.any? {|m| m.name == node.name }
     members.sort!{ |x,y| x.name <=> y.name }
     rs_members = []
     members.each_index do |n|


### PR DESCRIPTION
Chef::Node objects representing the same Chef node do not necessarily test as `==`, so the simple `include?` test doesn't work properly in all cases.
