### PR TITLE
Update definitions/mongodb.rb

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -141,7 +141,9 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   service name do
     supports :status => true, :restart => true
     action service_action
-    notifies service_notifies
+    service_notifies.each do |service_notify|
+      notifies :run, service_notify
+    end
     if !replicaset_name.nil?
       notifies :create, "ruby_block[config_replicaset]"
     end


### PR DESCRIPTION
This is a fix for bug 89 (https://github.com/edelight/chef-mongodb/issues/89). The bug was caused by a breaking change to chef itself between 10 and 11 -- see http://docs.opscode.com/breaking_changes_chef_11.html#single-notifies-for-notification for details. This fix will work in both chef 10 and 11.
