### PR TITLE
Replicate init breaks past second node

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -123,7 +123,7 @@ class Chef::ResourceDefinitionList::MongoDB
           Chef::Log.info("New config successfully applied: #{config.inspect}")
         end
         if !result.nil?
-          Chef::Log.error("configuring replicaset returned: #{result.inspect}")
+          Chef::Log.info("configuring replicaset returned: #{result.inspect}")
         end
       else
         # remove removed members from the replicaset and add the new ones
@@ -155,7 +155,7 @@ class Chef::ResourceDefinitionList::MongoDB
           Chef::Log.info("New config successfully applied: #{config.inspect}")
         end
         if !result.nil?
-          Chef::Log.error("configuring replicaset returned: #{result.inspect}")
+          Chef::Log.info("configuring replicaset returned: #{result.inspect}")
         end
       end
     elsif !result.fetch("errmsg", nil).nil?

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -109,7 +109,7 @@ class Chef::ResourceDefinitionList::MongoDB
         config['members'].collect!{ |m| {"_id" => m["_id"], "host" => mapping[m["host"]]} }
         config['version'] += 1
         
-        rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
+        rs_connection = Mongo::ReplSetConnection.new(old_members)
         admin = rs_connection['admin']
         cmd = BSON::OrderedHash.new
         cmd['replSetReconfig'] = config
@@ -139,7 +139,7 @@ class Chef::ResourceDefinitionList::MongoDB
           config['members'] << {"_id" => max_id, "host" => m}
         end
         
-        rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
+        rs_connection = Mongo::ReplSetConnection.new(old_members)
         admin = rs_connection['admin']
         
         cmd = BSON::OrderedHash.new

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -79,9 +79,17 @@ class Chef::ResourceDefinitionList::MongoDB
     end
     if result.fetch("ok", nil) == 1
       # everything is fine, do nothing
-    elsif result.fetch("errmsg", nil) == "already initialized"
+    elsif result.fetch("errmsg", nil) =~ %r/(\S+) is already initiated/ || (result.fetch("errmsg", nil) == "already initialized")
+      server,port = $1.nil? ? ['localhost',node['mongodb']['port']] : $1.split(":")
+      begin
+        connection = Mongo::Connection.new(server, port, :op_timeout => 5, :slave_ok => true)
+      rescue
+        abort("Could not connect to database: '#{server}:#{port}'")
+      end
+
       # check if both configs are the same
       config = connection['local']['system']['replset'].find_one({"_id" => name})
+
       if config['_id'] == name and config['members'] == rs_members
         # config is up-to-date, do nothing
         Chef::Log.info("Replicaset '#{name}' already configured")


### PR DESCRIPTION
This should hopefully address #63 and #58.

I was seeing something similar to #63 in my environment. When my 3rd+ node would come up I'd get an error that said "one of the first 2 servers already initiated", which wasn't handled and adding the new node would fail. So, this addresses that.

Also #58 which seems to just be Mongo::ReplSetConnection.new was expecting something different than it was getting. Not sure if this is an upstream change in the Mongo driver.

And now, I can happily launch 3+ instances and have them join the replicaset.  

mongodb-10gen -> 2.2.3
mongo gem -> 1.8.2
