### PR TITLE
replica set duplicate node fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,10 @@ default[:mongodb][:cluster_name] = nil
 default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
 
+default[:mongodb][:hidden] = false
+default[:mongodb][:priority] = 1
+default[:mongodb][:votes] = 1
+
 default[:mongodb][:enable_rest] = false
 
 default[:mongodb][:user] = "mongodb"

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -45,7 +45,7 @@ class Chef::ResourceDefinitionList::MongoDB
     end
     
     # Want the node originating the connection to be included in the replicaset
-    members << node unless members.include?(node)
+    members << node if ( members.select{|member| member['fqdn'] == node['fqdn'] }.length == 0)
     members.sort!{ |x,y| x.name <=> y.name }
     rs_members = []
     members.each_index do |n|

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -43,7 +43,7 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
       return
     end
-    
+
     # Want the node originating the connection to be included in the replicaset
     members << node if ( members.select{|member| member['fqdn'] == node['fqdn'] }.length == 0)
     members.sort!{ |x,y| x.name <=> y.name }
@@ -130,8 +130,8 @@ class Chef::ResourceDefinitionList::MongoDB
           max_id += 1
           config['members'] << {"_id" => max_id, "host" => m}
         end
-        
-        rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
+
+        rs_connection = Mongo::ReplSetConnection.new(old_members)
         admin = rs_connection['admin']
         
         cmd = BSON::OrderedHash.new

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,14 +23,21 @@ package node[:mongodb][:package_name] do
   action :install
 end
 
-needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))
+needs_mongo_gem = (node.recipes.include?("mongodb::replicaset") or node.recipes.include?("mongodb::mongos"))
 
+# install the mongo ruby gem at compile time to make it globally available
 if needs_mongo_gem
-  # install the mongo ruby gem at compile time to make it globally available
-  gem_package 'mongo' do
-    action :nothing
-  end.run_action(:install)
-  Gem.clear_paths
+  current_version = Gem::Version.new(Chef::VERSION)
+  if(current_version < Gem::Version.new('10.12.0'))
+    gem_package 'mongo' do
+      action :nothing
+    end.run_action(:install)
+    Gem.clear_paths
+  else
+    chef_gem 'mongo' do
+      action :install
+    end
+  end
 end
 
 if node.recipe?("mongodb::default") or node.recipe?("mongodb")


### PR DESCRIPTION
The replicaset recipe was attempting to configure mongo with duplicate nodes. This is because the library was failing to successfully check that the node was already in its list of members. This fix overcomes this by not comparing node objects with members but only comparing the fqdn of the node object with members. 

Also adding forwards compatibility support for installing "mongo" gem via chef_gem. 

Also changed the way that Mongo::ReplSetConnection.new is called from the mongodb library. The arguments didn't match those needed for the mongo gem (v 1.8.3)
