### PR TITLE
Changes from Parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ For examples see the USAGE section below.
 * `mongodb[:shard_name]` - Name of a shard, default is "default"
 * `mongodb[:sharded_collections]` - Define which collections are sharded
 * `mongodb[:replicaset_name]` - Define name of replicatset
+* `mongodb[:use_config_file]` - Use a config file instead of command
+    line arguments to start the server
+* `mongodb[:should_restart_server]` - Controls whether the cookbook
+    notifies the service to restart. Default is true; set to false and
+    config file changes will not result in a server restart.
 
 # USAGE:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default[:mongodb][:client_roles] = []
 default[:mongodb][:cluster_name] = nil
 default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
+default[:mongodb][:replicaset_prefix] = "rs_"
 
 default[:mongodb][:enable_rest] = false
 
@@ -37,6 +38,11 @@ default[:mongodb][:root_group] = "root"
 default[:mongodb][:init_dir] = "/etc/init.d"
 
 default[:mongodb][:init_script_template] = "mongodb.init.erb"
+
+# set this to true to use /etc/mongdb.conf instead of command line arguments
+default[:mongodb][:use_config_file] = false
+# set this to false to stop the cookbook from restarting mongodb when config files change
+default[:mongodb][:should_restart_server] = true
 
 case node['platform']
 when "freebsd"
@@ -52,6 +58,14 @@ when "centos","redhat","fedora","amazon","scientific"
   default[:mongodb][:group] = "mongod"
   default[:mongodb][:init_script_template] = "redhat-mongodb.init.erb"
 
+when "ubuntu"
+  default[:mongodb][:defaults_dir] = "/etc/default"
+  default[:mongodb][:init_dir] = "/etc/init"
+  default[:mongodb][:init_script_template] = "mongodb.upstart.erb"
+  default[:mongodb][:root_group] = "root"
+  default[:mongodb][:package_name] = "mongodb-10gen"
+  default[:mongodb][:apt_repo] = "ubuntu-upstart"
+
 else
   default[:mongodb][:defaults_dir] = "/etc/default"
   default[:mongodb][:root_group] = "root"
@@ -59,3 +73,14 @@ else
   default[:mongodb][:apt_repo] = "debian-sysvinit"
 
 end
+
+# whether to load a fresh replicaset or use EBS snapshots
+default[:mongodb][:use_ebs_snapshots] = false
+
+# If you're using EBS, piops volume info (only applicable to the raid_data recipe)
+default[:mongodb][:use_piops] = true
+default[:mongodb][:piops] = 1000
+default[:mongodb][:volsize] = 1000
+default[:mongodb][:vols] = 2
+# set blockdev read ahead to something sane
+default[:mongodb][:setra] = 512

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -84,3 +84,6 @@ default[:mongodb][:volsize] = 1000
 default[:mongodb][:vols] = 2
 # set blockdev read ahead to something sane
 default[:mongodb][:setra] = 512
+
+# identify the host that will be running backups - override this value in your node or role
+default[:mongodb][:backup_host] = nil

--- a/definitions/backup.rb
+++ b/definitions/backup.rb
@@ -1,0 +1,15 @@
+define :generate_raid_backups do
+  aws_creds = Chef::EncryptedDataBagItem.load("passwords", "aws")
+
+#  volumes = node[:backups][:mongo_volumes].join(" ")
+
+  template "/usr/local/bin/raid_snapshot.sh" do
+    source "raid_snapshot.sh.erb"
+    owner "root"
+    group "root"
+    mode "0755"
+    variables("seckey" => aws_creds["aws_secret_access_key"],
+              "awskey" => aws_creds["aws_access_key_id"])
+  end
+end
+

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -171,8 +171,8 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   service name do
     supports :status => true, :restart => true
     action service_action
-    unless service_notifies.empty?
-      notifies service_notifies
+    service_notifies.each do |service_notify|
+      notifies :run, service_notify
     end
     if !replicaset_name.nil?
       notifies :create, "ruby_block[config_replicaset]"

--- a/files/default/ec2-consistent-snapshot
+++ b/files/default/ec2-consistent-snapshot
@@ -1,0 +1,886 @@
+#!/usr/bin/perl
+#
+# Copyright (C) 2008-2011 Eric Hammond
+#
+use strict;
+use warnings;
+(our $Prog) = ($0 =~ m%([^/]+)$%);
+use Getopt::Long;
+use Pod::Usage;
+use File::Slurp;
+use IO::Socket::SSL;
+use Time::HiRes qw(ualarm usleep);
+use Net::Amazon::EC2 0.11;
+use POSIX ':signal_h';
+my $SIGALRM = 14;
+
+#---- OPTIONS ----
+
+my $Help                       = 0;
+my $Debug                      = 0;
+my $Quiet                      = 0;
+my $Noaction                   = 0;
+
+my $aws_access_key_id          = $ENV{AWS_ACCESS_KEY_ID} || $ENV{AMAZON_ACCESS_KEY_ID};
+my $aws_secret_access_key      = $ENV{AWS_SECRET_ACCESS_KEY} || $ENV{AMAZON_SECRET_ACCESS_KEY};
+my $aws_access_key_id_file     = $ENV{AWS_ACCESS_KEY_ID} || $ENV{AMAZON_ACCESS_KEY_ID};
+my $aws_secret_access_key_file = $ENV{AWS_SECRET_ACCESS_KEY} || $ENV{AMAZON_SECRET_ACCESS_KEY};
+my $aws_credentials_file       = $ENV{AWS_CREDENTIALS} || $ENV{AMAZON_CREDENTIALS};
+my $region                     = undef;
+my $ec2_endpoint               = undef;
+my $description                = $Prog;
+my $xfs_filesystem             = undef;
+my $mongo                      = 0;
+my $mongo_username             = undef;
+my $mongo_password             = undef;
+my $mongo_host                 = undef;
+my $mongo_port                 = 27017;
+my $mongo_stop                 = 0;
+my $mysql                      = 0;
+#my $mysql_defaults_file        = "$ENV{HOME}/.my.cnf";
+my $mysql_defaults_file        = undef;
+my $mysql_socket               = undef;
+my $mysql_master_status_file   = undef;
+my $mysql_username             = undef;
+my $mysql_password             = undef;
+my $mysql_host                 = undef;
+my $mysql_stop                 = 0;
+my $snapshot_timeout           = 10.0; # seconds
+my $lock_timeout               =  0.5; # seconds
+my $lock_tries                 = 60;
+my $lock_sleep                 =  5.0; # seconds
+
+Getopt::Long::config('no_ignore_case');
+GetOptions(
+  'help|?'                       => \$Help,
+  'debug'                        => \$Debug,
+  'quiet'                        => \$Quiet,
+  'noaction'                     => \$Noaction,
+
+  'aws-access-key-id=s'          => \$aws_access_key_id,
+  'aws-secret-access-key=s'      => \$aws_secret_access_key,
+  'aws-access-key-id-file=s'     => \$aws_access_key_id_file,
+  'aws-secret-access-key-file=s' => \$aws_secret_access_key_file,
+  'aws-credentials-file=s'       => \$aws_credentials_file,
+  'region=s'                     => \$region,
+  'ec2-endpoint=s'               => \$ec2_endpoint,
+  'description=s'                => \$description,
+  'xfs-filesystem=s'             => \$xfs_filesystem,
+  'mongo'                        => \$mongo,
+  'mongo-username=s'             => \$mongo_username,
+  'mongo-password=s'             => \$mongo_password,
+  'mongo-host=s'                 => \$mongo_host,
+  'mongo-port=s'                 => \$mongo_port,
+  'mongo-stop'                   => \$mongo_stop,
+  'mysql'                        => \$mysql,
+  'mysql-defaults-file=s'        => \$mysql_defaults_file,
+  'mysql-socket=i'               => \$mysql_socket,
+  'mysql-master-status-file=s'   => \$mysql_master_status_file,
+  'mysql-username=s'             => \$mysql_username,
+  'mysql-password=s'             => \$mysql_password,
+  'mysql-host=s'                 => \$mysql_host,
+  'mysql-stop'                   => \$mysql_stop,
+  'snapshot-timeout=s'           => \$snapshot_timeout,
+  'lock-timeout=s'               => \$lock_timeout,
+  'lock-tries=s'                 => \$lock_tries,
+  'lock-sleep=s'                 => \$lock_sleep,
+) or pod2usage(2);
+
+my $xfs_filesystem_frozen = 0;
+
+pod2usage(1) if $Help;
+
+my @volume_ids = @ARGV;
+pod2usage(2) unless scalar @volume_ids;
+
+$ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
+
+#---- MAIN ----
+
+($aws_access_key_id,      $aws_secret_access_key) = determine_access_keys(
+ $aws_access_key_id,      $aws_secret_access_key,
+ $aws_access_key_id_file, $aws_secret_access_key_file,
+ $aws_credentials_file,
+);
+die "$Prog: ERROR: Can't find AWS access key or secret access key"
+  unless $aws_access_key_id and $aws_secret_access_key;
+$Debug and warn "$Prog: Using AWS access key: $aws_access_key_id\n";
+
+#
+# Mongo
+#
+my $mongo_stopped = undef;
+my $mongo_dbh = undef;
+if ( $mongo_stop ) {
+  $mongo_stopped = mongo_stop();
+} elsif ( $mongo ) {
+  $mongo_dbh = mongo_connect($mongo_host, $mongo_port, $mongo_username, $mongo_password);
+  mongo_lock($mongo_dbh);
+}
+
+#
+# MySQL
+#
+my $mysql_stopped = undef;
+my $mysql_dbh = undef;
+if ( $mysql_stop ) {
+  $mysql_stopped = mysql_stop();
+} elsif ( $mysql ) {
+  $mysql_dbh = mysql_connect($mysql_host, $mysql_socket, $mysql_username, $mysql_password);
+  mysql_lock($mysql_dbh);
+}
+
+# sync may help flush changed blocks, increasing the consistency on
+# non-XFS file systems, and reducing the time the freeze locks changes
+# out on XFS file systems.
+run_command(['sync']);
+
+if ( $xfs_filesystem ) {
+    xfs_freeze($xfs_filesystem);
+    $xfs_filesystem_frozen = 1;
+}
+
+ebs_snapshot(\@volume_ids, $ec2_endpoint, $description);
+
+exit 0;
+
+END {
+  xfs_thaw($xfs_filesystem) if $xfs_filesystem_frozen;
+
+  if ( defined($mysql_master_status_file) ) {
+    $Debug and warn "$Prog: ", scalar localtime,
+      ": removing master info file: $mysql_master_status_file\n";
+    if ( not $Noaction ) {
+      unlink $mysql_master_status_file
+        or die "$Prog: Couldn't remove file: $mysql_master_status_file: $!\n";
+    }
+  }
+
+  if ( $mongo_stopped ) {
+    mongo_start();
+  } elsif ( $mongo_dbh ) {
+    mongo_unlock($mongo_dbh);
+    # We don't need to disconnect with the MongoDB module
+  }
+
+  if ( $mysql_stopped ) {
+    mysql_start();
+  } elsif ( $mysql_dbh ) {
+    mysql_unlock($mysql_dbh);
+    $Debug and warn "$Prog: ", scalar localtime, ": MySQL disconnect\n";
+    $mysql_dbh->disconnect;
+  }
+
+  $Debug and warn "$Prog: ", scalar localtime, ": done\n";
+}
+
+#---- METHODS ----
+
+sub ebs_snapshot {
+  my ($volume_ids, $ec2_endpoint, $description) = @_;
+
+  $Debug and warn "$Prog: ", scalar localtime, ": create EC2 object\n";
+  $Debug and warn "$Prog: Endpoint: $ec2_endpoint\n" if $ec2_endpoint;
+
+  # EC2 API object
+  my $ec2 = Net::Amazon::EC2->new(
+    AWSAccessKeyId  => $aws_access_key_id,
+    SecretAccessKey => $aws_secret_access_key,
+    ($ec2_endpoint ? (base_url => $ec2_endpoint) : ()),
+    # ($Debug ? (debug => 1) : ()),
+  );
+
+ VOLUME:
+  my $i = 0;
+  for my $volume_id ( @$volume_ids ) {
+    # Snapshot
+    $Debug and
+      warn "$Prog: ", scalar localtime, ": ec2-create-snapshot $volume_id\n";
+    if ( $Noaction ) {
+      warn "snapshot SKIPPED (--noaction)\n";
+      next VOLUME;
+    }
+
+    my $snapshot;
+    eval {
+      local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
+      ualarm($snapshot_timeout * 1_000_000);
+      $snapshot = $ec2->create_snapshot(
+        VolumeId    => $volume_id,
+        Description => "$description $i",
+      );
+      ualarm(0);
+    };
+    $i++;
+    ualarm(0);
+    if ( $@  ){
+      warn "$Prog: ERROR: create_snapshot: $@";
+      return undef;
+    }
+
+    my $snapshot_id;
+    if ( not defined $snapshot ) {
+      warn "$Prog: ERROR: create_snapshot returned undef\n";
+    } elsif ( not ref $snapshot ) {
+      warn "$Prog: ERROR: create_snapshot returned '$snapshot'\n";
+    } elsif ( $snapshot->can('snapshot_id') ) {
+      $snapshot_id = $snapshot->snapshot_id;
+      $Quiet or print "$snapshot_id\n";
+    } else {
+      for my $error ( @{$snapshot->errors} ) {
+        warn "$Prog: ERROR: ".$error->message."\n";
+      }
+    }
+  }
+}
+
+#
+# Mongo
+#
+sub mongo_connect {
+  my ($mongo_host, $mongo_port, $mongo_username, $mongo_password) = @_;
+
+  use MongoDB;
+  use MongoDB::Database;
+  use MongoDB::Admin;
+  use DateTime::Locale;
+  use DateTime::TimeZone;
+
+  $mongo_host ||= 'localhost';
+
+  $Debug and warn "$Prog: ", scalar localtime,
+                  ": mongo connect on ${mongo_host}:${mongo_port}\n";
+
+  my $mongo_conn = MongoDB::Connection->new(host => "${mongo_host}:${mongo_port}")
+    or die "$Prog: ERROR: Unable to connect to mongo"
+         . " on $mongo_host";
+
+  if (defined $mongo_username && defined $mongo_password) {
+    $mongo_conn->authenticate('admin', $mongo_username, $mongo_password)
+      or die "$Prog: ERROR: Unable to connect to mongo"
+           . " on $mongo_host as $mongo_username";
+  }
+
+  my $mongo_dbh = MongoDB::Admin->new(connection => $mongo_conn)
+    or die "$Prog: ERROR: Unable to get Mongo admin connection"
+           . " on $mongo_host";
+
+  return $mongo_dbh;
+}
+
+sub mongo_lock {
+  my ($mongo_dbh) = @_;
+
+  # Don't worry about retry since Mongo has reconnect option on by default
+  $Debug and warn "$Prog: ", scalar localtime, ": locking mongo\n";
+
+  if ( $Noaction ) {
+    warn "mongo lock SKIPPED (--noaction)\n";
+  }
+  $mongo_dbh->fsync_lock();
+
+  $Debug and warn "$Prog: ", scalar localtime, ": mongo locked\n";
+
+  return 1;
+}
+
+sub mongo_unlock {
+  my ($mongo_dbh) = @_;
+
+  # Don't worry about retry since Mongo has reconnect option on by default
+  $Debug and warn "$Prog: ", scalar localtime, ": unlocking mongo\n";
+
+  if ( $Noaction ) {
+    warn "mongo unlock SKIPPED (--noaction)\n";
+  }
+  $mongo_dbh->unlock();
+
+  $Debug and warn "$Prog: ", scalar localtime, ": mongo unlocked\n";
+
+}
+
+sub mongo_stop {
+  $Debug and warn "$Prog: ", scalar localtime, ": mongo stop\n";
+
+  my $result = system('/etc/init.d/mongodb', 'stop');
+
+  if ( $result != 0 ) {
+    die "$Prog: Unable to stop mongod: $? $!";
+  }
+
+  return 1;
+}
+
+sub mongo_start {
+  $Debug and warn "$Prog: ", scalar localtime, ": mongo start\n";
+
+  my $result = system('/etc/init.d/mongodb', 'start');
+
+  if ( $result != 0 ) {
+    warn "$Prog: Unable to start mongod: $? $!";
+  }
+}
+
+
+#
+# MySQL
+#
+sub mysql_connect {
+  my ($mysql_host, $mysql_socket, $mysql_username, $mysql_password) = @_;
+  my $dsn_extra = "";
+
+  require DBI;
+  DBI->import;
+
+  if ( defined($mysql_defaults_file) )
+  {
+    ($mysql_host, $mysql_username, $mysql_password) = read_mydefaultsfile(
+      $mysql_defaults_file,
+    );
+  } else {
+    ($mysql_host, $mysql_username, $mysql_password) = read_mycnf(
+      $mysql_host, $mysql_username, $mysql_password,
+    );
+  }
+  if( defined($mysql_socket) ) {
+    $dsn_extra .= "mysql_socket=$mysql_socket;";
+  }
+
+  $mysql_host ||= 'localhost';
+
+  $Debug and warn "$Prog: ", scalar localtime,
+                  ": MySQL connect as $mysql_username\n";
+
+  my $mysql_dbh = DBI->connect("DBI:mysql:;${dsn_extra}host=$mysql_host",
+                         $mysql_username, $mysql_password)
+    or die "$Prog: ERROR: Unable to connect to MySQL"
+         . " on $mysql_host as $mysql_username";
+
+  return $mysql_dbh;
+}
+
+sub mysql_lock {
+  my ($mysql_dbh) = @_;
+
+  # Don't pass FLUSH TABLES statements on to replication slaves
+  # as this can interfere with long-running queries on the slaves.
+  $mysql_dbh->do(q{ SET SQL_LOG_BIN=0 }) unless $Noaction;
+
+  # Try a flush first without locking so the later flush with lock
+  # goes faster.  This may not be needed as it seems to interfere with
+  # some statements anyway.
+  sql_timeout_retry(
+    q{ FLUSH LOCAL TABLES },
+    "MySQL flush",
+    $lock_timeout,
+    $lock_tries,
+    $lock_sleep,
+  );
+
+  # Get a lock on the entire database
+  sql_timeout_retry(
+    q{ FLUSH LOCAL TABLES WITH READ LOCK },
+    "MySQL flush & lock",
+    $lock_timeout,
+    $lock_tries,
+    $lock_sleep,
+  );
+
+  my ($mysql_logfile, $mysql_position,
+      $mysql_binlog_do_db, $mysql_binlog_ignore_db);
+  if ( not $Noaction ) {
+    # This might be a slave database already
+    my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
+    $mysql_logfile           = $slave_status->{Master_Log_File};
+    $mysql_position          = $slave_status->{Read_Master_Log_Pos};
+    $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
+    $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
+
+    # or this might be the master
+    ($mysql_logfile, $mysql_position,
+     $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
+      $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  })
+      unless $mysql_logfile;
+  }
+
+  $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
+
+  print "$Prog: master_log_file=\"$mysql_logfile\",",
+              " master_log_pos=$mysql_position\n"
+    if $mysql_logfile and not $Quiet;
+
+  if ( defined($mysql_master_status_file) && $mysql_logfile ) {
+    $Debug and warn "$Prog: ", scalar localtime,
+      ": writing MASTER STATUS to $mysql_master_status_file\n";
+    if ( not $Noaction ) {
+      open(MYSQLMASTERSTATUS,"> $mysql_master_status_file") or
+        die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
+      print MYSQLMASTERSTATUS <<"EOM";
+master_log_file="$mysql_logfile"
+master_log_pos="$mysql_position"
+master_binlog_do_db="$mysql_binlog_do_db"
+master_binlog_ignore_db="$mysql_binlog_ignore_db"
+EOM
+      close(MYSQLMASTERSTATUS);
+    }
+  }
+
+  return ($mysql_logfile, $mysql_position);
+}
+
+sub mysql_unlock {
+  my ($mysql_dbh) = @_;
+
+  $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
+  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+
+}
+
+sub mysql_stop {
+  $Debug and warn "$Prog: ", scalar localtime, ": MySQL stop\n";
+
+  my $result = system('/usr/bin/mysqladmin', 'shutdown');
+
+  if ( $result != 0 ) {
+    die "$Prog: Unable to stop mysqld: $? $!";
+  }
+
+  return 1;
+}
+
+sub mysql_start {
+  $Debug and warn "$Prog: ", scalar localtime, ": MySQL start\n";
+
+  my $result = system('/etc/init.d/mysql', 'start');
+
+  if ( $result != 0 ) {
+    warn "$Prog: Unable to start mysqld: $? $!";
+  }
+}
+
+# See also:
+#http://search.cpan.org/dist/DBI/DBI.pm#Signal_Handling_and_Canceling_Operations
+sub sql_timeout_retry {
+  my ($sql, $description, $lock_timeout, $lock_tries, $lock_sleep) = @_;
+
+  my $action = POSIX::SigAction->new(
+    sub { die "timeout" },
+    POSIX::SigSet->new( SIGALRM ),
+  );
+  my $oldaction = POSIX::SigAction->new();
+  sigaction($SIGALRM, $action, $oldaction);
+ LOCK:
+  while ( $lock_tries -- ) {
+    $Debug and warn "$Prog: ", scalar localtime, ": $description\n";
+    eval {
+      ualarm($lock_timeout * 1_000_000);
+      $mysql_dbh->do($sql) unless $Noaction;
+      ualarm(0);
+    };
+    ualarm(0);
+    last LOCK unless $@ =~ /timeout/;
+
+  } continue {
+    $Quiet or  warn "$Prog: MySQL timeout at $lock_timeout sec\n";
+    $Debug and warn "$Prog: Trying again in $lock_sleep seconds\n";
+    usleep($lock_sleep * 1_000_000);
+    #TBD: May need to reopen $mysql_dbh here as the handle may not be clean.
+  }
+  sigaction($SIGALRM, $oldaction);
+  die "$Prog: ERROR: MySQL failure: $@" if $@;
+}
+
+sub xfs_freeze {
+  my ($xfs_filesystem) = @_;
+
+  run_command(['xfs_freeze', '-f', $xfs_filesystem]);
+}
+
+sub xfs_thaw {
+  my ($xfs_filesystem) = @_;
+
+  run_command(['xfs_freeze', '-u', $xfs_filesystem]);
+}
+
+# mysql defaults-file
+sub read_mydefaultsfile {
+  my ($mysql_defaults_file) = @_;
+
+  open(MYCNF, $mysql_defaults_file)
+    or die "$Prog: ERROR: Couldn't open defaults-file $mysql_defaults_file\n";
+  while ( defined (my $line = <MYCNF>) ) {
+    $mysql_host     = $1 if $line =~ m%^\s*host\s*=\s*"?(\S+?)"?$%
+                        and not defined $mysql_host;
+    $mysql_username = $1 if $line =~ m%^\s*user\s*=\s*"?(\S+?)"?$%
+                        and not defined $mysql_username;
+    $mysql_password = $1 if $line =~ m%^\s*password\s*=\s*"?(\S+?)"?$%
+                        and not defined $mysql_password;
+  }
+  close(MYCNF);
+
+  return ($mysql_host, $mysql_username, $mysql_password);
+}
+
+# Look for the MySQL username/password in $HOME/.my.cnf
+sub read_mycnf {
+  my ($mysql_host, $mysql_username, $mysql_password) = @_;
+
+  open(MYCNF, "$ENV{HOME}/.my.cnf")
+    or return($mysql_host, $mysql_username, $mysql_password);
+  while ( defined (my $line = <MYCNF>) ) {
+    $mysql_host     = $1 if $line =~ m%^\s*host\s*=\s*"?(\S+?)"?$%
+                        and not defined $mysql_host;
+    $mysql_username = $1 if $line =~ m%^\s*user\s*=\s*"?(\S+?)"?$%
+                        and not defined $mysql_username;
+    $mysql_password = $1 if $line =~ m%^\s*password\s*=\s*"?(\S+?)"?$%
+                        and not defined $mysql_password;
+  }
+  close(MYCNF);
+
+  return ($mysql_host, $mysql_username, $mysql_password);
+}
+
+
+# Figure out which AWS access keys to use
+sub determine_access_keys {
+  my ($aws_access_key_id,      $aws_secret_access_key,
+      $aws_access_key_id_file, $aws_secret_access_key_file,
+      $aws_credentials_file,
+     ) = @_;
+
+  # 1. --aws-access-key-id and --aws-secret-access-key
+  return ($aws_access_key_id, $aws_secret_access_key)
+    if $aws_access_key_id;
+
+  # 2. --aws-access-key-id-file and --aws-secret-access-key-file
+  if ( $aws_access_key_id_file ) {
+    die "$Prog: Please provide both --aws-access-key-id-file and --aws-secret-access-key-file"
+      unless $aws_secret_access_key_file;
+    $aws_access_key_id    = File::Slurp::read_file($aws_access_key_id_file);
+    $aws_secret_access_key= File::Slurp::read_file($aws_secret_access_key_file);
+    chomp($aws_access_key_id);
+    chomp($aws_secret_access_key);
+    return ($aws_access_key_id, $aws_secret_access_key);
+  }
+
+  # 3. $AWS_CREDENTIALS or $HOME/.awssecret
+  return read_awssecret($aws_credentials_file);
+}
+
+
+# Look for the access keys in $AWS_CREDENTIALS or ~/.awssecret
+sub read_awssecret {
+  my ($aws_credentials_file) = @_;
+      $aws_credentials_file  ||= "$ENV{HOME}/.awssecret";
+  my ($aws_access_key_id, $aws_secret_access_key);
+  eval {
+    ($aws_access_key_id, $aws_secret_access_key) =
+      File::Slurp::read_file($aws_credentials_file);
+    chomp $aws_access_key_id;
+    chomp $aws_secret_access_key;
+  };
+  return ($aws_access_key_id, $aws_secret_access_key);
+}
+
+# Run a system command, warning if there are problems.
+# Pass in reference to an array of command args.
+sub run_command {
+  my ($command) = @_;
+
+  $Debug and warn "$Prog: ", scalar localtime, ": @$command\n";
+  return if $Noaction;
+  eval {
+    system(@$command) and die "failed($?)\n";
+  };
+  warn "$Prog: ERROR: @$command: $@" if $@;
+}
+
+
+=head1 NAME
+
+ec2-consistent-snapshot - Create snapshot, locking db and freezing file system
+
+=head1 SYNOPSIS
+
+ ec2-consistent-snapshot [opts] VOLUMEID...
+
+=head1 OPTIONS
+
+ -h --help      Print help and exit.
+ -d --debug     Debug mode.
+ -q --quiet     Quiet mode.
+ -n --noaction  Don't do it. Just say what you would have done.
+
+ --aws-access-key-id KEY
+ --aws-secret-access-key SECRET
+
+   Amazon AWS access key and secret access key.  Defaults to
+   environment variables or .awssecret file contents described below.
+
+ --aws-access-key-id-file KEYFILE
+ --aws-secret-access-key-file SECRETFILE
+
+   Files containing Amazon AWS access key and secret access key.
+   Defaults to environment variables or .awssecret file contents
+   described below.
+
+ --aws-credentials-file CREDENTIALSFILE
+
+   File containing both the Amazon AWS access key and secret access
+   key on seprate lines and in that order.  Defaults to contents of
+   $AWS_CREDENTIALS environment variable or the value $HOME/.awssecret
+
+ --region REGION
+
+   Specify a different region like "eu-west-1".  Defaults to
+   "us-east-1".
+
+ --description DESCRIPTION
+
+   Specify a description string for the EBS snapshot.  Defaults to the
+   name of the program.
+
+ --xfs-filesystem MOUNTPOINT
+
+   Indicates that the volume contains an XFS file system at the specified
+   mount point, which will be flushed and frozen during the snapshot.
+
+ --mongo
+
+   Indicates that the volume contains data files for a running Mongo
+   database, which will be flushed and locked during the snapshot.
+
+ --mongo-host HOST
+ --mongo-port PORT
+ --mongo-username USER
+ --mongo-password PASS
+
+   Mongo host, port, username, and password used to flush logs if there
+   is authentication required on the admin database.
+
+ --mongo-stop
+
+   Indicates that the volume contains data files for a running Mongo
+   instance.  The instance is shutdown before the snapshot is initiated
+   and restarted afterwards. [EXPERIMENTAL]
+
+ --mysql
+
+   Indicates that the volume contains data files for a running MySQL
+   database, which will be flushed and locked during the snapshot.
+
+ --mysql-defaults-file FILE
+
+   MySQL defaults file, containing host, username and password, this
+   option will ignore the --mysql-host, --mysql-username,
+   --mysql-password parameters
+
+ --mysql-host HOST
+ --mysql-socket PATH
+ --mysql-username USER
+ --mysql-password PASS
+
+   MySQL host, socket path, username, and password used to flush logs
+   and lock tables.  User must have appropriate permissions.
+   Defaults to $HOME/.my.cnf file contents.
+
+ --mysql-master-status-file FILE
+
+   Store the MASTER STATUS output in a file on the snapshot. It will
+   be removed after the EBS snapshot is taken.  This option will be
+   ignored with --mysql-stop
+
+ --mysql-stop
+
+   Indicates that the volume contains data files for a running MySQL
+   database.  The database is shutdown before the snapshot is initiated
+   and restarted afterwards. [EXPERIMENTAL]
+
+ --snapshot-timeout SECONDS
+
+   How many seconds to wait for the snapshot-create to return.
+   Defaults to 10.0
+
+ --lock-timeout SECONDS
+
+   How many seconds to wait for a database lock. Defaults to 0.5.
+   Making this too large can force other processes to wait while this
+   process waits for a lock.  Better to make it small and try lots of
+   times.
+
+ --lock-tries COUNT
+
+   How many times to try to get a database lock before failing.
+   Defaults to 60.
+
+ --lock-sleep SECONDS
+
+   How many seconds to sleep between database lock tries.  Defaults
+   to 5.0.
+
+=head1 ARGUMENTS
+
+ VOLUMEID       EBS volume id(s) for which to create a snapshot.
+
+=head1 DESCRIPTION
+
+This program creates an EBS snapshot for an Amazon EC2 EBS volume.  To
+help ensure consistent data in the snapshot, it tries to flush and
+freeze the file system first as well as flushing and locking the
+database, if applicable.
+
+There are a number of timeouts to reduce the risk of interfering with
+the normal database operation while improving the chances of getting a
+consistent snapshot.
+
+If you have multiple EBS volumes in a RAID configuration, you can
+specify all of the volume ids on the command line and it will create
+snapshots for each while the filesystem and database are locked.  Note
+that it is your responsibility to keep track of the resulting snapshot
+ids and to figure out how to put these back together when you need to
+restore the RAID setup.
+
+If you have multiple EBS volumes which are hosting different file
+systems, it might be better to simply run the command once for each
+volume id.
+
+=head1 EXAMPLES
+
+Snapshot a volume which has a MySQL database on XFS under /vol:
+
+ ec2-consistent-snapshot --mysql --xfs-filesystem /vol vol-VOLUMEID
+
+Snapshot a volume which has a Mongo database on XFS under /data:
+
+ ec2-consistent-snapshot --mongo --xfs-filesystem /data vol-VOLUMEID
+
+Snapshot a volume with XFS on /var/local but no MySQL database:
+
+ ec2-consistent-snapshot --xfs-filesystem /var/local vol-VOLUMEID
+
+Snapshot four European volumes in a RAID configuration with MySQL on
+XFS, saving the snapshots with a description marking the current time:
+
+ ec2-consistent-snapshot                                      \
+   --mysql                                                    \
+   --xfs-filesystem /vol                                      \
+   --region eu-west-1                                         \
+   --description "RAID snapshot $(date +'%Y-%m-%d %H:%M:%S')" \
+   vol-VOL1 vol-VOL2 vol-VOL3 vol-VOL4
+
+Snapshot four us-east-1 volumes in a RAID configuration with Mongo on
+XFS, saving the snapshots with a description marking the current time:
+
+ ec2-consistent-snapshot                                      \
+   --mongo                                                    \
+   --xfs-filesystem /data                                     \
+   --region us-east-1                                         \
+   --description "RAID snapshot $(date +'%Y-%m-%d %H:%M:%S')" \
+   vol-VOL1 vol-VOL2 vol-VOL3 vol-VOL4 vol-VOL5 vol-VOL6 vol-VOL7 vol-VOL8
+
+=head1 ENVIRONMENT
+
+  $AWS_ACCESS_KEY_ID
+
+    Default value for access key
+    Can be overridden by command line options.
+
+  $AWS_SECRET_ACCESS_KEY
+
+    Default value for secret access key
+    Can be overridden by command line options.
+
+  $AWS_CREDENTIALS
+
+    Default value for filename containing both access key and secret
+    access key on separate lines and in that order. Can be overriden
+    by the --aws-credentials command line option.
+
+=head1 FILES
+
+  $HOME/.my.cnf
+
+    Default values for MySQL user and password are sought here in the
+    standard format.
+
+  $HOME/.awssecret
+
+    Default values for access key and secret access keys are sought
+    here.  Can be overridden by environment variables and command line
+    options.
+
+=head1 INSTALLATION
+
+On most Ubuntu releases, the B<ec2-consistent-snapshot> package can be
+installed directly from the Alestic.com PPA using the following
+commands:
+
+ sudo add-apt-repository ppa:alestic
+ sudo apt-get update
+ sudo apt-get install ec2-consistent-snapshot
+
+This program may also require the installation of the Net::Amazon::EC2
+Perl package from CPAN.  On Ubuntu 10.04 Lucid and higher, this should
+happen automatically by the dependency on the libnet-amazon-ec2-perl
+package.
+
+On some earlier releases of Ubuntu you can install the required
+package with the following command:
+
+ sudo PERL_MM_USE_DEFAULT=1 cpan Net::Amazon::EC2
+
+On Ubuntu 8.04 Hardy, use the following commands instead:
+
+ code=$(lsb_release -cs)
+ echo "deb http://ppa.launchpad.net/alestic/ppa/ubuntu $code main"|
+   sudo tee /etc/apt/sources.list.d/alestic-ppa.list
+ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BE09C571
+ sudo apt-get update
+ sudo apt-get install ec2-consistent-snapshot build-essential
+ sudo cpan Net::Amazon::EC2
+
+The default values can be accepted for most of the prompts, though it
+is necessary to select a CPAN mirror on Hardy.
+
+=head1 SEE ALSO
+
+  Amazon EC2
+  Amazon EC2 EBS (Elastic Block Store)
+  ec2-create-snapshot
+
+=head1 CAVEATS
+
+This program currently supports the MySQL database and the XFS file
+system.  Patches are welcomed for other databases and file systems.
+
+This program tries hard to figure out some values are for the AWS key
+and AWS secret access key.  In fact, it tries too hard.  This results
+in possibly using some credentials it finds that are not the correct
+ones you wish to use, especially if you are operating in an
+environment where multiple sets of credentials are in use.
+
+=head1 BUGS
+
+Please report bugs at https://bugs.launchpad.net/ec2-consistent-snapshot
+
+=head1 CREDITS
+
+Thanks to the following for performing tests on early versions,
+providing feedback, and patches:
+
+  David Erickson
+  Steve Caldwell
+  Gryp
+
+=head1 AUTHOR
+
+Eric Hammond <ehammond@thinksome.com>
+
+=head1 LICENSE
+
+Copyright (C) 2009-2011 Eric Hammond <ehammond@thinksome.com>
+
+Licensed under the Apache License, Version 2.0, see
+http://www.apache.org/licenses/LICENSE-2.0
+
+=cut

--- a/files/default/mongodb.init
+++ b/files/default/mongodb.init
@@ -1,0 +1,216 @@
+#!/bin/sh
+#
+# init.d script with LSB support.
+#
+# Copyright (c) 2007 Javier Fernandez-Sanguino <jfs@debian.org>
+# Copyright (c) 2011 edelight GmbH
+#       Author: Markus Korn <markus.korn@edelight.de>
+#
+# This is free software; you may redistribute it and/or modify
+# it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2,
+# or (at your option) any later version.
+#
+# This is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License with
+# the Debian operating system, in /usr/share/common-licenses/GPL;  if
+# not, write to the Free Software Foundation, Inc., 59 Temple Place,
+# Suite 330, Boston, MA 02111-1307 USA
+#
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DESC=database
+DAEMON=/usr/bin/mongod
+DAEMON_OPTS="--config /etc/mongodb.conf"
+
+ENABLE_MONGODB=yes
+
+NAME=`basename $0`
+
+# Include mongodb defaults if available
+if [ -f /etc/default/$NAME ] ; then
+	. /etc/default/$NAME
+fi
+
+PIDFILE=/var/run/$NAME.pid
+
+if test ! -x $DAEMON; then
+    echo "Could not find $DAEMON"
+    exit 0
+fi
+
+if test "x$ENABLE_MONGODB" != "xyes"; then
+    exit 0
+fi
+
+. /lib/lsb/init-functions
+
+STARTTIME=1
+DIETIME=10                  # Time to wait for the server to die, in seconds
+                            # If this value is set too low you might not
+                            # let some servers to die gracefully and
+                            # 'restart' will not work
+
+DAEMONUSER=${DAEMONUSER:-mongodb}
+
+# debugging
+echo "** Running $NAME ($DAEMON $DAEMON_OPTS)"
+
+set -e
+
+
+running_pid() {
+# Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] &&  return 1
+    cmd=`cat /proc/$pid/cmdline | tr "\000" "\n"|head -n 1 |cut -d : -f 1`
+    # Is this the expected server
+    [ "$cmd" != "$name" ] &&  return 1
+    return 0
+}
+
+running() {
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    pid=`cat $PIDFILE`
+    running_pid $pid $DAEMON || return 1
+    return 0
+}
+
+start_server() {
+# Start the process using the wrapper
+            start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
+                        --make-pidfile --chuid $DAEMONUSER \
+                        --exec $DAEMON -- $DAEMON_OPTS
+            errcode=$?
+	return $errcode
+}
+
+stop_server() {
+# Stop the process using the wrapper
+            start-stop-daemon --stop --quiet --pidfile $PIDFILE \
+                        --retry 300 \
+                        --user $DAEMONUSER \
+                        --exec $DAEMON
+            errcode=$?
+	return $errcode
+}
+
+force_stop() {
+# Force the process to die killing it manually
+	[ ! -e "$PIDFILE" ] && return
+	if running ; then
+		kill -15 $pid
+	# Is it really dead?
+		sleep "$DIETIME"s
+		if running ; then
+			kill -9 $pid
+			sleep "$DIETIME"s
+			if running ; then
+				echo "Cannot kill $NAME (pid=$pid)!"
+				exit 1
+			fi
+		fi
+	fi
+	rm -f $PIDFILE
+}
+
+
+case "$1" in
+  start)
+	log_daemon_msg "Starting $DESC" "$NAME"
+        # Check if it's running first
+        if running ;  then
+            log_progress_msg "apparently already running"
+            log_end_msg 0
+            exit 0
+        fi
+        if start_server ; then
+            # NOTE: Some servers might die some time after they start,
+            # this code will detect this issue if STARTTIME is set
+            # to a reasonable value
+            [ -n "$STARTTIME" ] && sleep $STARTTIME # Wait some time 
+            if  running ;  then
+                # It's ok, the server started and is running
+                log_end_msg 0
+            else
+                # It is not running after we did start
+                log_end_msg 1
+            fi
+        else
+            # Either we could not start it
+            log_end_msg 1
+        fi
+	;;
+  stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        if running ; then
+            # Only stop the server if we see it running
+			errcode=0
+            stop_server || errcode=$?
+            log_end_msg $errcode
+        else
+            # If it's not running don't do anything
+            log_progress_msg "apparently not running"
+            log_end_msg 0
+            exit 0
+        fi
+        ;;
+  force-stop)
+        # First try to stop gracefully the program
+        $0 stop
+        if running; then
+            # If it's still running try to kill it more forcefully
+            log_daemon_msg "Stopping (force) $DESC" "$NAME"
+			errcode=0
+            force_stop || errcode=$?
+            log_end_msg $errcode
+        fi
+	;;
+  restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+		errcode=0
+        stop_server || errcode=$?
+        # Wait some sensible amount, some server need this
+        [ -n "$DIETIME" ] && sleep $DIETIME
+        start_server || errcode=$?
+        [ -n "$STARTTIME" ] && sleep $STARTTIME
+        running || errcode=$?
+        log_end_msg $errcode
+	;;
+  status)
+
+        log_daemon_msg "Checking status of $DESC" "$NAME"
+        if running ;  then
+            log_progress_msg "running"
+            log_end_msg 0
+        else
+            log_progress_msg "apparently not running"
+            log_end_msg 1
+            exit 1
+        fi
+        ;;
+  # MongoDB can't reload its configuration.
+  reload)
+        log_warning_msg "Reloading $NAME daemon: not implemented, as the daemon"
+        log_warning_msg "cannot re-read the config file (use restart)."
+        ;;
+
+  *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|force-stop|restart|force-reload|status}" >&2
+	exit 1
+	;;
+esac
+
+exit 0
+

--- a/libraries/ec2.rb
+++ b/libraries/ec2.rb
@@ -1,0 +1,90 @@
+class Chef::ResourceDefinitionList::MongoDB
+  # Returns an array of snapshot ids that represent the latest consistent 
+  # snapshot of the N raided <volumes>.  Each volume's snapshot description is
+  # expected to have the form "Mongo RAID Snapshot <timestamp> <disk_number>".
+  # A set of snapshots are considered consistent if they share the timestamp in
+  # the description.  If no such group of snapshots are found, this returns
+  # nil.  The returned snapshots array will be parallel to the volumes array,
+  # i.e the latest snapshot for the Nth volume in the array will be the Nth
+  # snapshot in the result.
+  def self.find_snapshots(key, secret_key, volumes, clustername)
+    require 'aws-sdk'
+
+    if volumes.size == 0
+      Chef::Log.info "No reference volumes given.  Returning empty list."
+      return []
+    end
+
+    # Compute the latest snapshots.
+    ec2 = AWS::EC2.new(
+          :access_key_id => key,
+          :secret_access_key => secret_key)
+
+    # This is an array of arrays.  snapshots[i] will have the sorted list of
+    # snapshots for volumes[i].  The snapshots are sorted by description which
+    # has the snapshot timestamp in it, so the snapshots will be sorted in
+    # ascending order of timestamp.
+    snapshots = []
+
+    # We put all of this logic in a memoize block so each fetch of a snapshot
+    # attribute will not result in a network connection.
+    AWS.memoize do
+      for volume_id in volumes
+        # Get the list of snapshots for the currenet volume.
+        vol_snapshots = ec2.snapshots.select { |s| s.volume_id == volume_id }
+        vol_snapshots.sort! { |x, y| x.description <=> y.description }
+        # Remove the incomplete snapshots.  This makes the assumption that
+        # later snapshots will not finish before earlier snapshots.
+        while not vol_snapshots.size == 0 and
+              vol_snapshots.last.status != :completed
+          vol_snapshots.pop
+        end
+        snapshots.push vol_snapshots
+      end
+      Chef::Log.info "Found the list of snapshots"
+        r = /Mongo RAID (Snaphsot|Snapshot) ([^ ]+) ([[:digit:]]+)/
+      match_found = false
+      # Now we need to find the last complete set of snapshots.  This is done 
+      # by parsing the timestamp from the description of the newest snapshot
+      # for each volume (snapshots[i].last) and seeing if they are all the same.
+      # If they aren't, we pop the snapshot with the newest timestamp and 
+      # try again.  If any of the volumes has no more snapshots, then we don't
+      # have a consistent snapshot, so we return nil.
+      while not match_found
+        if snapshots[0].size == 0
+          return nil
+        end
+        # Keep track of the index of the snapshot array that has the
+        # description which is lexicographically the greatest. This should
+        # also be the newest snapshot created.
+        largest = 0
+        date = r.match(snapshots[0].last.description)[2]
+        match_found = true
+
+        # Iterate over the newest snapshot for other volumes to see if the date
+        # matches the first one.
+        for i in 1..(snapshots.size() - 1)
+          if snapshots[i].size == 0
+            return nil
+          end
+
+          if snapshots[largest].last.description < snapshots[i].last.description
+            largest = i
+          end
+
+          if r.match(snapshots[i].last.description)[2] != date
+            match_found = false
+          end
+        end
+
+        if not match_found
+          snapshots[largest].pop
+        end
+      end
+      if match_found
+        Chef::Log.info "Starting from #{snapshots[0].last.description}"
+        return snapshots.map { |list| list.pop.id }
+      end
+    end
+  end
+end

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -27,7 +27,7 @@ class Chef::ResourceDefinitionList::MongoDB
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     if members.length == 0
       if Chef::Config[:solo]
         abort("Cannot configure replicaset '#{name}', no member nodes found")
@@ -36,14 +36,14 @@ class Chef::ResourceDefinitionList::MongoDB
         return
       end
     end
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
     rescue
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
       return
     end
-    
+
     # Want the node originating the connection to be included in the replicaset
     members << node unless members.include?(node)
     members.sort!{ |x,y| x.name <=> y.name }
@@ -53,24 +53,24 @@ class Chef::ResourceDefinitionList::MongoDB
       rs_members << {"_id" => n, "host" => "#{members[n]['fqdn']}:#{port}"}
     end
 
-    
+
     Chef::Log.info(
       "Configuring replicaset with members #{members.collect{ |n| n['hostname'] }.join(', ')}"
     )
-    
+
     rs_member_ips = []
     members.each_index do |n|
       port = members[n]['mongodb']['port']
       rs_member_ips << {"_id" => n, "host" => "#{members[n]['ipaddress']}:#{port}"}
     end
-    
+
     admin = connection['admin']
     cmd = BSON::OrderedHash.new
     cmd['replSetInitiate'] = {
         "_id" => name,
         "members" => rs_members
     }
-    
+
     begin
       result = admin.command(cmd, :check_response => false)
     rescue Mongo::OperationTimeout
@@ -100,7 +100,7 @@ class Chef::ResourceDefinitionList::MongoDB
         end
         config['members'].collect!{ |m| {"_id" => m["_id"], "host" => mapping[m["host"]]} }
         config['version'] += 1
-        
+
         rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
         admin = rs_connection['admin']
         cmd = BSON::OrderedHash.new
@@ -123,20 +123,20 @@ class Chef::ResourceDefinitionList::MongoDB
         rs_members.collect!{ |member| member['host'] }
         config['version'] += 1
         old_members = config['members'].collect{ |member| member['host'] }
-        members_delete = old_members - rs_members        
+        members_delete = old_members - rs_members
         config['members'] = config['members'].delete_if{ |m| members_delete.include?(m['host']) }
         members_add = rs_members - old_members
         members_add.each do |m|
           max_id += 1
           config['members'] << {"_id" => max_id, "host" => m}
         end
-        
+
         rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
         admin = rs_connection['admin']
-        
+
         cmd = BSON::OrderedHash.new
         cmd['replSetReconfig'] = config
-        
+
         result = nil
         begin
           result = admin.command(cmd, :check_response => false)
@@ -154,24 +154,24 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.error("Failed to configure replicaset, reason: #{result.inspect}")
     end
   end
-  
+
   def self.configure_shards(node, shard_nodes)
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     shard_groups = Hash.new{|h,k| h[k] = []}
-    
+
     shard_nodes.each do |n|
       if n['recipes'].include?('mongodb::replicaset')
-        key = "rs_#{n['mongodb']['shard_name']}"
+        key = "#{n['mongodb']['replicaset_prefix']}#{n['mongodb']['shard_name']}"
       else
         key = '_single'
       end
       shard_groups[key] << "#{n['fqdn']}:#{n['mongodb']['port']}"
     end
     Chef::Log.info(shard_groups.inspect)
-    
+
     shard_members = []
     shard_groups.each do |name, members|
       if name == "_single"
@@ -181,16 +181,16 @@ class Chef::ResourceDefinitionList::MongoDB
       end
     end
     Chef::Log.info(shard_members.inspect)
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
     rescue Exception => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
       return
     end
-    
+
     admin = connection['admin']
-    
+
     shard_members.each do |shard|
       cmd = BSON::OrderedHash.new
       cmd['addShard'] = shard
@@ -202,24 +202,24 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.info(result.inspect)
     end
   end
-  
+
   def self.configure_sharded_collections(node, sharded_collections)
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
     rescue Exception => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
       return
     end
-    
+
     admin = connection['admin']
-    
+
     databases = sharded_collections.keys.collect{ |x| x.split(".").first}.uniq
     Chef::Log.info("enable sharding for these databases: '#{databases.inspect}'")
-    
+
     databases.each do |db_name|
       cmd = BSON::OrderedHash.new
       cmd['enablesharding'] = db_name
@@ -241,7 +241,7 @@ class Chef::ResourceDefinitionList::MongoDB
         Chef::Log.info("Enabled sharding for database '#{db_name}'")
       end
     end
-    
+
     sharded_collections.each do |name, key|
       cmd = BSON::OrderedHash.new
       cmd['shardcollection'] = name
@@ -264,7 +264,7 @@ class Chef::ResourceDefinitionList::MongoDB
         Chef::Log.info("Sharding for collection '#{result['collectionsharded']}' enabled")
       end
     end
-  
+
   end
-  
+
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,8 @@ recipe "mongodb::replicaset", "Installs and configures a mongodb replicaset"
 
 depends "apt"
 depends "yum"
+depends "aws"
+depends "cpan"
 
 %w{ ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|
   supports os

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -61,4 +61,15 @@ cookbook_file "/usr/local/bin/ec2-consistent-snapshot" do
   mode "0755"
 end
 
-
+# install backup cron on the backup node
+cron "mongo_backups" do
+  user "root"
+  minute "0"
+  hour "*/2"
+  command "/bin/bash /usr/local/bin/raid_snapshot.sh"
+  if node[:hostname] == node[:mongodb][:backup_host]
+    action :create
+  else
+    action :delete
+  end
+end

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -1,0 +1,64 @@
+include_recipe "cpan::bootstrap"
+
+packages = %w{libio-socket-ssl-perl libfile-slurp-perl libnet-amazon-ec2-perl libdatetime-perl}
+packages.each do |p|
+  package p do
+    action :install
+  end
+end
+
+generate_raid_backups {}
+
+cpan_client 'Any::Moose' do
+  action 'install'
+  install_type 'cpan_module'
+  user 'root'
+  group 'root'
+  force true
+end
+
+cpan_client 'Path::Class' do
+  action 'install'
+  install_type 'cpan_module'
+  user 'root'
+  group 'root'
+  force true
+end
+
+cpan_client 'Module::Build' do
+  action 'install'
+  install_type 'cpan_module'
+  user 'root'
+  group 'root'
+  force true
+end
+
+#cpan_client 'Path::Class' do
+#  action 'install'
+#  user 'root'
+#  group 'root'
+#end
+
+cpan_client 'MongoDB' do
+  action 'install'
+  install_type 'cpan_module'
+  user 'root'
+  group 'root'
+  force true
+end
+
+cpan_client 'MongoDB::Admin' do
+  action 'install'
+  install_type 'cpan_module'
+  user 'root'
+  group 'root'
+end
+
+cookbook_file "/usr/local/bin/ec2-consistent-snapshot" do
+  source "ec2-consistent-snapshot"
+  owner "root"
+  group "root"
+  mode "0755"
+end
+
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,9 @@ end
 needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))
 
 if needs_mongo_gem
+  chef_gem 'mongo' do
+    action :install
+  end
   # install the mongo ruby gem at compile time to make it globally available
   gem_package 'mongo' do
     action :nothing
@@ -42,5 +45,13 @@ if node.recipe?("mongodb::default") or node.recipe?("mongodb")
     logpath      node['mongodb']['logpath']
     dbpath       node['mongodb']['dbpath']
     enable_rest  node['mongodb']['enable_rest']
+  end
+end
+
+# if the host has ganglia, install the mongo plugin.
+if node.recipes.include?("ganglia::default")
+  include_recipe "ganglia::default"
+  ganglia_python "mongodb" do
+    action :enable
   end
 end

--- a/recipes/raid_data.rb
+++ b/recipes/raid_data.rb
@@ -1,0 +1,42 @@
+include_recipe "aws"
+
+gem_package "aws-sdk" do
+  version "1.3.5"
+  action :nothing
+end.run_action(:install)
+Gem.clear_paths
+
+if node[:mongodb][:use_piops]
+  create_raided_drives_from_snapshot do
+    disk_counts node[:mongodb][:vols].to_i
+    disk_size node[:mongodb][:volsize].to_i
+    disk_type 'io1'
+    disk_piops node[:mongodb][:piops].to_i
+    level 0
+    filesystem "ext4"
+  end
+else
+  create_raided_drives_from_snapshot do
+    disk_counts node[:mongodb][:vols].to_i
+    disk_size node[:mongodb][:volsize].to_i
+    level 0
+    filesystem "ext4"
+  end
+end
+
+ENV['mongodir'] = node[:mongodb][:dbpath]
+script "update_permissions" do
+  interpreter "bash"
+  user "root"
+  code <<-EOH
+    chown -R #{node[:mongodb][:user]}.#{node[:mongodb][:group]} $mongodir
+  EOH
+end
+
+script "add_array_to_mdadm" do
+  interpreter "bash"
+  user "root"
+  code "mdadm --detail --scan >> /etc/mdadm/mdadm.conf"
+  not_if "grep ^ARRAY /etc/mdadm/mdadm.conf"
+end
+

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -21,6 +21,9 @@ include_recipe "mongodb"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe
 if !node.recipe?("mongodb::shard")
+  # these are used in the library for searches
+  node.set["mongodb_cluster_name"] = node['mongodb']['cluster_name']
+  node.set["mongodb_shard_name"] = node['mongodb']['shard_name']
   mongodb_instance "mongodb" do
     mongodb_type "mongod"
     port         node['mongodb']['port']

--- a/templates/default/ganglia/mongodb.py.erb
+++ b/templates/default/ganglia/mongodb.py.erb
@@ -1,0 +1,496 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# MongoDB gmond module for Ganglia
+#
+# Copyright (C) 2011 by Michael T. Conigliaro <mike [at] conigliaro [dot] org>.
+# All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import json
+import os
+import re
+import socket
+import string
+import time
+import copy
+
+NAME_PREFIX = 'mongodb_'
+PARAMS = {
+    'server_status' : '~/mongodb-osx-x86_64-1.8.1/bin/mongo --host mongodb04.example.com --port 27018 --quiet --eval "printjson(db.serverStatus())"',
+    'rs_status'     : '~/mongodb-osx-x86_64-1.8.1/bin/mongo --host mongodb04.example.com --port 27018 --quiet --eval "printjson(rs.status())"'
+}
+METRICS = {
+    'time' : 0,
+    'data' : {}
+}
+LAST_METRICS = copy.deepcopy(METRICS)
+METRICS_CACHE_TTL = 3
+
+
+def flatten(d, pre = '', sep = '_'):
+    """Flatten a dict (i.e. dict['a']['b']['c'] => dict['a_b_c'])"""
+
+    new_d = {}
+    for k,v in d.items():
+        if type(v) == dict:
+            new_d.update(flatten(d[k], '%s%s%s' % (pre, k, sep)))
+        else:
+            new_d['%s%s' % (pre, k)] = v
+    return new_d
+
+
+def get_metrics():
+    """Return all metrics"""
+
+    global METRICS, LAST_METRICS
+
+    if (time.time() - METRICS['time']) > METRICS_CACHE_TTL:
+
+        metrics = {}
+        for status_type in PARAMS.keys():
+
+            # get raw metric data
+            io = os.popen(PARAMS[status_type])
+
+            # clean up
+            metrics_str = ''.join(io.readlines()).strip() # convert to string
+            metrics_str = re.sub('\w+\((.*)\)', r"\1", metrics_str) # remove functions
+
+            # convert to flattened dict
+            try:
+                if status_type == 'server_status':
+                    metrics.update(flatten(json.loads(metrics_str)))
+                else:
+                    metrics.update(flatten(json.loads(metrics_str), pre='%s_' % status_type))
+            except ValueError:
+                metrics = {}
+
+        # update cache
+        LAST_METRICS = copy.deepcopy(METRICS)
+        METRICS = {
+            'time': time.time(),
+            'data': metrics
+        }
+
+    return [METRICS, LAST_METRICS]
+
+
+def get_value(name):
+    """Return a value for the requested metric"""
+
+     # get metrics
+    metrics = get_metrics()[0]
+
+    # get value
+    name = name[len(NAME_PREFIX):] # remove prefix from name
+    try:
+        result = metrics['data'][name]
+    except StandardError:
+        result = 0
+
+    return result
+
+
+def get_rate(name):
+    """Return change over time for the requested metric"""
+
+    # get metrics
+    [curr_metrics, last_metrics] = get_metrics()
+
+    # get rate
+    name = name[len(NAME_PREFIX):] # remove prefix from name
+
+    try:
+        rate = float(curr_metrics['data'][name] - last_metrics['data'][name]) / \
+               float(curr_metrics['time'] - last_metrics['time'])
+        if rate < 0:
+            rate = float(0)
+    except StandardError:
+        rate = float(0)
+
+    return rate
+
+
+def get_opcounter_rate(name):
+    """Return change over time for an opcounter metric"""
+
+    master_rate = get_rate(name)
+    repl_rate = get_rate(name.replace('opcounters_', 'opcountersRepl_'))
+
+    return master_rate + repl_rate
+
+
+def get_globalLock_ratio(name):
+    """Return the global lock ratio"""
+
+    try:
+        result = get_rate(NAME_PREFIX + 'globalLock_lockTime') / \
+                 get_rate(NAME_PREFIX + 'globalLock_totalTime') * 100
+    except ZeroDivisionError:
+        result = 0
+
+    return result
+
+
+def get_indexCounters_btree_miss_ratio(name):
+    """Return the btree miss ratio"""
+
+    try:
+        result = get_rate(NAME_PREFIX + 'indexCounters_btree_misses') / \
+                 get_rate(NAME_PREFIX + 'indexCounters_btree_accesses') * 100
+    except ZeroDivisionError:
+        result = 0
+
+    return result
+
+
+def get_connections_current_ratio(name):
+    """Return the percentage of connections used"""
+
+    try:
+        result = float(get_value(NAME_PREFIX + 'connections_current')) / \
+                 float(get_value(NAME_PREFIX + 'connections_available')) * 100
+    except ZeroDivisionError:
+        result = 0
+
+    return result
+
+
+def get_slave_delay(name):
+    """Return the replica set slave delay"""
+
+    # get metrics
+    metrics = get_metrics()[0]
+
+    # no point checking my optime if i'm not replicating
+    if 'rs_status_myState' not in metrics['data'] or metrics['data']['rs_status_myState'] != 2:
+        result = 0
+
+    # compare my optime with the master's
+    else:
+        master = {}
+        slave = {}
+        try:
+            for member in metrics['data']['rs_status_members']:
+                if member['state'] == 1:
+                    master = member
+                if member['name'].split(':')[0] == socket.getfqdn():
+                    slave = member
+            result = max(0, master['optime']['t'] - slave['optime']['t']) / 1000
+        except KeyError:
+            result = 0
+
+    return result
+
+
+def get_asserts_total_rate(name):
+    """Return the total number of asserts per second"""
+
+    return float(reduce(lambda memo,obj: memo + get_rate('%sasserts_%s' % (NAME_PREFIX, obj)),
+                       ['regular', 'warning', 'msg', 'user', 'rollovers'], 0))
+
+
+def metric_init(lparams):
+    """Initialize metric descriptors"""
+
+    global PARAMS
+
+    # set parameters
+    for key in lparams:
+        PARAMS[key] = lparams[key]
+
+    # define descriptors
+    time_max = 60
+    groups = 'mongodb'
+    descriptors = [
+        {
+            'name': NAME_PREFIX + 'opcounters_insert',
+            'call_back': get_opcounter_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Inserts/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Inserts',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'opcounters_query',
+            'call_back': get_opcounter_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Queries/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Queries',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'opcounters_update',
+            'call_back': get_opcounter_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Updates/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Updates',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'opcounters_delete',
+            'call_back': get_opcounter_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Deletes/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Deletes',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'opcounters_getmore',
+            'call_back': get_opcounter_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Getmores/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Getmores',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'opcounters_command',
+            'call_back': get_opcounter_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Commands/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Commands',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'backgroundFlushing_flushes',
+            'call_back': get_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Flushes/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Flushes',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'mem_mapped',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'MB',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Memory-mapped Data',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'mem_virtual',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'MB',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Process Virtual Size',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'mem_resident',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'MB',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Process Resident Size',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'extra_info_page_faults',
+            'call_back': get_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Faults/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Page Faults',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_ratio',
+            'call_back': get_globalLock_ratio,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': '%',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Global Write Lock Ratio',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'indexCounters_btree_miss_ratio',
+            'call_back': get_indexCounters_btree_miss_ratio,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': '%',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'BTree Page Miss Ratio',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_currentQueue_total',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Operations',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Total Operations Waiting for Lock',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_currentQueue_readers',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Operations',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Readers Waiting for Lock',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_currentQueue_writers',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Operations',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Writers Waiting for Lock',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_activeClients_total',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Clients',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Total Active Clients',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_activeClients_readers',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Clients',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Active Readers',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'globalLock_activeClients_writers',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Clients',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Active Writers',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'connections_current',
+            'call_back': get_value,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Connections',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Open Connections',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'connections_current_ratio',
+            'call_back': get_connections_current_ratio,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': '%',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Percentage of Connections Used',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'slave_delay',
+            'call_back': get_slave_delay,
+            'time_max': time_max,
+            'value_type': 'uint',
+            'units': 'Seconds',
+            'slope': 'both',
+            'format': '%u',
+            'description': 'Replica Set Slave Delay',
+            'groups': groups
+        },
+        {
+            'name': NAME_PREFIX + 'asserts_total',
+            'call_back': get_asserts_total_rate,
+            'time_max': time_max,
+            'value_type': 'float',
+            'units': 'Asserts/Sec',
+            'slope': 'both',
+            'format': '%f',
+            'description': 'Asserts',
+            'groups': groups
+        }
+    ]
+
+    return descriptors
+
+
+def metric_cleanup():
+    """Cleanup"""
+
+    pass
+
+
+# the following code is for debugging and testing
+if __name__ == '__main__':
+    descriptors = metric_init(PARAMS)
+    while True:
+        for d in descriptors:
+            print (('%s = %s') % (d['name'], d['format'])) % (d['call_back'](d['name']))
+        print ''
+        time.sleep(METRICS_CACHE_TTL)

--- a/templates/default/ganglia/mongodb.pyconf.erb
+++ b/templates/default/ganglia/mongodb.pyconf.erb
@@ -1,0 +1,109 @@
+modules {
+    module {
+        name = "mongodb"
+        language = "python"
+        param server_status {
+            value = "mongo --quiet --eval 'printjson(db.serverStatus())'"
+        }
+        param rs_status {
+            value = "mongo --quiet --eval 'printjson(rs.status())'"
+        }
+    }
+}
+
+collection_group {
+    collect_every = 30
+    time_threshold = 90
+    metric {
+        name = "mongodb_opcounters_insert"
+        title = "Inserts"
+    }
+    metric {
+        name = "mongodb_opcounters_query"
+        title = "Queries"
+    }
+    metric {
+        name = "mongodb_opcounters_update"
+        title = "Updates"
+    }
+    metric {
+        name = "mongodb_opcounters_delete"
+        title = "Deletes"
+    }
+    metric {
+        name = "mongodb_opcounters_getmore"
+        title = "Getmores"
+    }
+    metric {
+        name = "mongodb_opcounters_command"
+        title = "Commands"
+    }
+    metric {
+        name = "mongodb_backgroundFlushing_flushes"
+        title = "Flushes"
+    }
+    metric {
+        name = "mongodb_mem_mapped"
+        title = "Memory-mapped Data"
+    }
+    metric {
+        name = "mongodb_mem_virtual"
+        title = "Process Virtual Size"
+    }
+    metric {
+        name = "mongodb_mem_resident"
+        title = "Process Resident Size"
+    }
+    metric {
+        name = "mongodb_extra_info_page_faults"
+        title = "Page Faults"
+    }
+    metric {
+        name = "mongodb_globalLock_ratio"
+        title = "Global Write Lock Ratio"
+    }
+    metric {
+        name = "mongodb_indexCounters_btree_miss_ratio"
+        title = "BTree Page Miss Ratio"
+    }
+    metric {
+        name = "mongodb_globalLock_currentQueue_total"
+        title = "Total Operations Waiting for Lock"
+    }
+    metric {
+        name = "mongodb_globalLock_currentQueue_readers"
+        title = "Readers Waiting for Lock"
+    }
+    metric {
+        name = "mongodb_globalLock_currentQueue_writers"
+        title = "Writers Waiting for Lock"
+    }
+    metric {
+        name = "mongodb_globalLock_activeClients_total"
+        title = "Total Active Clients"
+    }
+    metric {
+        name = "mongodb_globalLock_activeClients_readers"
+        title = "Active Readers"
+    }
+    metric {
+        name = "mongodb_globalLock_activeClients_writers"
+        title = "Active Writers"
+    }
+    metric {
+        name = "mongodb_connections_current"
+        title = "Open Connections"
+    }
+    metric {
+        name = "mongodb_connections_current_ratio"
+        title = "Open Connections"
+    }
+    metric {
+        name = "mongodb_slave_delay"
+        title = "Replica Set Slave Delay"
+    }
+    metric {
+        name = "mongodb_asserts_total"
+        title = "Asserts per Second"
+    }
+}

--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -1,0 +1,90 @@
+# mongodb.conf
+<%= @replicaset_name ? "replSet=#{@replicaset_name}" : "" %>
+
+# should we use rest
+rest=<%= @enable_rest %>
+
+# Where to store the data.
+
+# Note: if you run mongodb as a non-root user (recommended) you may
+# need to create and set permissions for this directory manually,
+# e.g., if the parent directory isn't mutable by the mongodb user.
+dbpath=<%= @dbpath %>
+
+#where to log
+logpath=<%= @logpath %>
+
+logappend=true
+
+port = <%= @port %>
+
+# Disables write-ahead journaling
+# nojournal = true
+
+# Enables periodic logging of CPU utilization and I/O wait
+cpu = true
+
+# Turn on/off security.  Off is currently the default
+#noauth = true
+#auth = true
+
+# Verbose logging output.
+#verbose = true
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+#diaglog = 0
+
+# Ignore query hints
+#nohints = true
+
+# Disable the HTTP interface (Defaults to localhost:27018).
+#nohttpinterface = true
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation.
+#noprealloc = true
+
+# Specify .ns file size for new databases.
+nssize = 256
+
+# Accout token for Mongo monitoring server.
+#mms-token = <token>
+
+# Server name for Mongo monitoring server.
+#mms-name = <server-name>
+
+# Ping interval for Mongo monitoring server.
+#mms-interval = <seconds>
+
+# Replication Options
+
+# in master/slave replicated mongo databases, specify here whether
+# this is a slave or master
+#slave = true
+#source = master.example.com
+# Slave only: specify a single database to replicate
+#only = master.example.com
+# or
+#master = true
+#source = slave.example.com
+
+# in replica set configuration, specify the name of the replica set
+# replSet = setname 

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -6,6 +6,10 @@ NAME="<%= @name %>"
 
 DAEMON_OPTS=""
 
+<% if @config %>
+# we're using a config file; load parameters there.
+DAEMON_OPTS="$DAEMON_OPTS --config <%= @config %>"
+<% else %>
 <% if @bind_ip -%>
 DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
 <% end -%>
@@ -13,7 +17,6 @@ DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
 <%= @dbpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --dbpath #{@dbpath}\"" : "" %>
 <%= @logpath ? "DAEMON_OPTS=\"$DAEMON_OPTS --logpath #{@logpath}\"" : "" %>
 
-<%= @config ? "DAEMON_OPTS=\"$DAEMON_OPTS --config #{@config}\"" : "" %>
 <%= @configdb ? "DAEMON_OPTS=\"$DAEMON_OPTS --configdb #{@configdb}\"" : "" %>
 
 <%= @configsrv ? "DAEMON_OPTS=\"$DAEMON_OPTS --configsvr\"" : "" %>
@@ -30,4 +33,5 @@ DAEMON_OPTS="$DAEMON_OPTS --rest"
 <% if %w(centos redhat fedora amazon).include? node.platform -%>
 DAEMON_OPTS="$DAEMON_OPTS --fork"
 DBPATH="<%= @dbpath %>"
+<% end -%>
 <% end -%>

--- a/templates/default/mongodb.upstart.erb
+++ b/templates/default/mongodb.upstart.erb
@@ -1,0 +1,28 @@
+# Ubuntu upstart file at /etc/init/mongodb.conf
+
+limit nofile 50000 50000
+
+kill timeout 300 # wait 300s between SIGTERM and SIGKILL.
+
+pre-start script
+  mkdir -p <%= node['mongodb']['dbpath'] %>
+  mkdir -p <%= node['mongodb']['logpath'] %>
+
+  vol=$(grep <%= node['mongodb']['dbpath'] %> /proc/mounts |awk '{print $1}')
+  disks=$(mdadm --detail $vol |grep active |awk '{print $7}')
+
+  for n in $vol $disks ; do
+    blockdev --setra <%= node['mongodb']['setra'] %> $n
+  done
+
+end script
+
+start on runlevel [2345]
+stop on runlevel [06]
+
+script
+  ENABLE_MONGODB="yes"
+  if [ -f <%= node['mongodb']['defaults_dir'] %>/mongodb ]; then . <%= node['mongodb']['defaults_dir'] %>/mongodb; fi
+  if [ "x$ENABLE_MONGODB" = "xyes" ]; then exec start-stop-daemon --start --quiet --chuid mongodb --exec  /usr/bin/mongod -- --config /etc/mongodb.conf; fi
+end script
+

--- a/templates/default/raid_snapshot.sh.erb
+++ b/templates/default/raid_snapshot.sh.erb
@@ -1,0 +1,25 @@
+#!/bin/bash
+export AWS_ACCESS_KEY_ID="<%=@awskey%>"
+export AWS_SECRET_ACCESS_KEY="<%=@seckey%>"
+
+daily_backup="/var/tmp/.mongo_daily_backup_timestamp"
+day_ago="/var/tmp//.mongo_day_ago_timestamp"
+
+touch -d "$(date -d '1 days ago')" $day_ago
+
+# if no daily_backup timestamp, make one
+if ! test -f $daily_backup ; then
+  string="Daily Mongo RAID Snapshot $(date +%F:%T)"
+  touch -d "$(date -d '2 days ago')" $daily_backup
+fi
+
+# if daily_backup timestamp is older than a day_ago, make daily snapshot
+if [ $daily_backup -ot $day_ago ] ; then
+  string="Daily Mongo RAID Snapshot $(date +%F:%T)"
+  touch $daily_backup
+else
+  string="Mongo RAID Snapshot $(date +%F:%T)"
+fi
+
+/usr/local/bin/ec2-consistent-snapshot --quiet --mongo --region us-east-1 --description "$string" <%= node['backups']['mongo_volumes'].join(" ") %>
+


### PR DESCRIPTION
small changes:
- optionally use a config file instead of command line arguments to start mongo
- optionally suppress server restarts on config change (sometimes you want to
  restart production servers more carefully)
- if ganglia is installed, report metrics
- make the replicaset prefix "rs_" customizable via attribute
- add ubuntu as a platform and use upstart when on ubuntu

big changes:
- new recipe to backup mongo using ec2-consistent-snapshot
- new recipe to put the mongo db mountpoint on a set of raided EBS volumes
  *\* when using raided EBS volumes, automatically start new instances
  using snapshots to make joining the cluster fast and easy
