### PR TITLE
Configurable Package Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For examples see the USAGE section below.
 * `mongodb[:shard_name]` - Name of a shard, default is "default"
 * `mongodb[:sharded_collections]` - Define which collections are sharded
 * `mongodb[:replicaset_name]` - Define name of replicatset
+* `mongodb[:package_version]` - Version of the MongoDB package to install, default is nil
 
 # USAGE:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,3 +59,5 @@ else
   default[:mongodb][:apt_repo] = "debian-sysvinit"
 
 end
+
+default[:mongodb][:package_version] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -67,3 +67,8 @@ attribute "mongodb/bind_ip",
   :display_name => "Bind address",
   :description => "MongoDB instance bind address",
   :default => nil
+
+attribute "mongodb/package_version",
+  :display_name => "MongoDB package version",
+  :description => "Version of the MongoDB package to install",
+  :default => nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,7 @@
 
 package node[:mongodb][:package_name] do
   action :install
+  version node[:mongodb][:package_version]
 end
 
 needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))


### PR DESCRIPTION
After the release of MongoDB 2.4 it is not possible to install MongoDB 2.2 from the 10gen repo because they released no mongo22-10gen-server RPM. I added a mongodb.package_version to specify the version to be installed.
