### PR TITLE
Fix apt settings

### DIFF
--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -31,9 +31,9 @@ when "debian"
 
   apt_repository "10gen" do
     uri "http://downloads-distro.mongodb.org/repo/#{node[:mongodb][:apt_repo]}"
-    distribution "dist"
-    components ["10gen"]
-    keyserver "hkp://keyserver.ubuntu.com:80"
+    distributions %w[dist]
+    components %w[10gen]
+    keyserver "hkp://keyserver.ubuntu.com"
     key "7F0CEB10"
     action :add
     notifies :run, "execute[apt-get update]", :immediately


### PR DESCRIPTION
On my vagrant Ubuntu Precise64 VM using chef v0.10.10, the 10gen_repo apt settings weren't working. This is what I did to fix it.

Possibly related to https://github.com/edelight/chef-mongodb/issues/99
