### PR TITLE
Fix the cookbook for CentOS/RedHat if the 10gen repo is not used

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,7 +48,20 @@ when "freebsd"
   default[:mongodb][:root_group] = "wheel"
   default[:mongodb][:package_name] = "mongodb"
 
-when "centos","redhat","fedora","amazon","scientific"
+when "centos","redhat"
+  default[:mongodb][:defaults_dir] = "/etc/sysconfig"
+  default[:mongodb][:init_script_template] = "redhat-mongodb.init.erb"
+  if node['mongodb']['repo_10gen']
+    default[:mongodb][:package_name] = "mongo-10gen-server"
+    default[:mongodb][:user] = "mongod"
+    default[:mongodb][:group] = "mongod"
+  else
+    default[:mongodb][:package_name] = "mongodb-server"
+    default[:mongodb][:user] = "mongodb"
+    default[:mongodb][:group] = "mongodb"
+  end
+
+when "fedora","amazon","scientific"
   default[:mongodb][:defaults_dir] = "/etc/sysconfig"
   default[:mongodb][:package_name] = "mongo-10gen-server"
   default[:mongodb][:user] = "mongod"

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -133,7 +133,10 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     group node['mongodb']['root_group']
     owner "root"
     mode "0755"
-    variables :provides => name
+    variables(
+      :provides => name,
+      :mongo_user => node['mongodb']['user']
+    )
     notifies :restart, "service[#{name}]"
   end
   

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -38,7 +38,7 @@ when "debian"
     action :add
     notifies :run, "execute[apt-get update]", :immediately
   end
-  node['mongodb']['repo_10gen'] = true
+  node.set['mongodb']['repo_10gen'] = true
 
 when "rhel","fedora"
   yum_repository "10gen" do
@@ -46,9 +46,9 @@ when "rhel","fedora"
     url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
     action :add
   end
-  node['mongodb']['repo_10gen'] = true
+  node.set['mongodb']['repo_10gen'] = true
 
 else
   Chef::Log.warn("Adding the #{node['platform']} 10gen repository is not yet not supported by this cookbook")
-  node['mongodb']['repo_10gen'] = false
+  node.set['mongodb']['repo_10gen'] = false
 end

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -38,6 +38,7 @@ when "debian"
     action :add
     notifies :run, "execute[apt-get update]", :immediately
   end
+  node['mongodb']['repo_10gen'] = true
 
 when "rhel","fedora"
   yum_repository "10gen" do
@@ -45,7 +46,9 @@ when "rhel","fedora"
     url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
     action :add
   end
+  node['mongodb']['repo_10gen'] = true
 
 else
-    Chef::Log.warn("Adding the #{node['platform']} 10gen repository is not yet not supported by this cookbook")
+  Chef::Log.warn("Adding the #{node['platform']} 10gen repository is not yet not supported by this cookbook")
+  node['mongodb']['repo_10gen'] = false
 end

--- a/templates/default/redhat-mongodb.init.erb
+++ b/templates/default/redhat-mongodb.init.erb
@@ -12,7 +12,7 @@
 
 SYSCONFIG="/etc/sysconfig/<%= @provides %>"
 DAEMON=/usr/bin/mongod
-MONGO_USER=mongod
+MONGO_USER=<%= @mongo_user %>
 
 . "$SYSCONFIG" || true
 


### PR DESCRIPTION
As the 10gen_repo is not part of the default runlist, the cookbook breaks if one just includes the default recipe on a CentOS/RedHat machine. This pull request fixes the default properties, so that the default cookbook installs mongodb from the distribution repos if only the default recipe is included.
