### PR TITLE
specify cookbook name in definition template

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -85,6 +85,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   # default file
   template "#{node['mongodb']['defaults_dir']}/#{name}" do
     action :create
+    cookbook 'mongodb'
     source "mongodb.default.erb"
     group node['mongodb']['root_group']
     owner "root"
@@ -129,6 +130,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   # init script
   template "#{node['mongodb']['init_dir']}/#{name}" do
     action :create
+    cookbook 'mongodb'
     source node[:mongodb][:init_script_template]
     group node['mongodb']['root_group']
     owner "root"


### PR DESCRIPTION
when template used in definition. template search source in current cookbook.
but in definition, the current template's coobook is not 'mongodb' but the cookbook using mongodb.

So, template used in definition should specify the cookbook name.
