### PR TITLE
Set open file limit for MongoDB process in Debian/Ubuntu to 64000

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,14 @@ default[:mongodb][:user] = "mongodb"
 default[:mongodb][:group] = "mongodb"
 default[:mongodb][:root_group] = "root"
 
+# http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+default[:mongodb][:ulimit][:file_size] = "unlimited"
+default[:mongodb][:ulimit][:cpu_time] = "unlimited"
+default[:mongodb][:ulimit][:virtual_memory] = "unlimited"
+default[:mongodb][:ulimit][:open_files] = 64000
+default[:mongodb][:ulimit][:memory_size] = "unlimited"
+default[:mongodb][:ulimit][:processes] = 32000
+
 default[:mongodb][:init_dir] = "/etc/init.d"
 
 default[:mongodb][:init_script_template] = "mongodb.init.erb"

--- a/templates/default/mongodb.init.erb
+++ b/templates/default/mongodb.init.erb
@@ -41,7 +41,12 @@ ENABLE_MONGODB=yes
 NAME=<%= @provides %>
 
 <% if %w{ ubuntu debian }.include? node.platform -%>
-ulimit -n 64000
+ulimit -f <%= node.mongodb.ulimit.file_size %>
+ulimit -t <%= node.mongodb.ulimit.cpu_time %>
+ulimit -v <%= node.mongodb.ulimit.virtual_memory %>
+ulimit -n <%= node.mongodb.ulimit.open_files %>
+ulimit -m <%= node.mongodb.ulimit.memory_size %>
+ulimit -u <%= node.mongodb.ulimit.processes %>
 <% end -%>
 
 # Include mongodb defaults if available

--- a/templates/default/mongodb.init.erb
+++ b/templates/default/mongodb.init.erb
@@ -40,6 +40,10 @@ ENABLE_MONGODB=yes
 
 NAME=<%= @provides %>
 
+<% if %w{ ubuntu debian }.include? node.platform -%>
+ulimit -n 64000
+<% end -%>
+
 # Include mongodb defaults if available
 if [ -f /etc/default/$NAME ] ; then
 	. /etc/default/$NAME


### PR DESCRIPTION
- See http://docs.mongodb.org/manual/reference/ulimit/
- Fixes error: "Too many open files"
