### PR TITLE
Pull request that fix the link to "Sharding + Replication" wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The setup is not much different to the one described above. All you have to do i
 `mongodb::replicaset` recipe to all shard nodes, and make sure that all shard
 nodes which should be in the same replicaset have the same shard name.
 
-For more details, you can find a [tutorial for Sharding + Replication](https://github.com/edelight/chef-cookbooks/wiki/MongoDB%3A-Replication%2BSharding) in the wiki.
+For more details, you can find a [tutorial for Sharding + Replication](https://github.com/edelight/chef-mongodb/wiki/MongoDB%3A-Replication%2BSharding) in the wiki.
 
 # LICENSE and AUTHOR:
 


### PR DESCRIPTION
The link was pointing to the old repository url
