### PR TITLE
Abriter Support and Fix for Node Inclusion in Replica Set setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For examples see the USAGE section below.
 * `mongodb[:shard_name]` - Name of a shard, default is "default"
 * `mongodb[:sharded_collections]` - Define which collections are sharded
 * `mongodb[:replicaset_name]` - Define name of replicatset
+* `mongodb[:arbiter]` - Boolean indicating if this replicaset member should be an [arbiter](http://docs.mongodb.org/manual/core/replication/#replica-set-arbiters).
 
 # USAGE:
 
@@ -88,6 +89,8 @@ The result is a new system service with
 Add `mongodb::replicaset` to the node's run_list. Also choose a name for your
 replicaset cluster and set the value of `node[:mongodb][:cluster_name]` for each
 member to this name.
+
+If you want the node to be an arbiter, set `node[:mongodb][:arbiter]` to be `true`.
 
 ## Sharding
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,8 @@ default[:mongodb][:init_dir] = "/etc/init.d"
 
 default[:mongodb][:init_script_template] = "mongodb.init.erb"
 
+default[:mongodb][:arbiter] = false
+
 case node['platform']
 when "freebsd"
   default[:mongodb][:defaults_dir] = "/etc/rc.conf.d"

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -27,7 +27,7 @@ class Chef::ResourceDefinitionList::MongoDB
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     if members.length == 0
       if Chef::Config[:solo]
         abort("Cannot configure replicaset '#{name}', no member nodes found")
@@ -36,41 +36,48 @@ class Chef::ResourceDefinitionList::MongoDB
         return
       end
     end
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
     rescue
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
       return
     end
-    
+
     # Want the node originating the connection to be included in the replicaset
-    members << node unless members.include?(node)
+    members << node unless members.any? {|m| m.name == node.name }
+
+    if members.select { |m| m['mongodb']['arbiter'] }.length > 1
+      Chef::Log.warn("Multiple Arbiters Found, will not configure replicaset")
+      return
+    end
+
     members.sort!{ |x,y| x.name <=> y.name }
     rs_members = []
     members.each_index do |n|
       port = members[n]['mongodb']['port']
-      rs_members << {"_id" => n, "host" => "#{members[n]['fqdn']}:#{port}"}
+      config = {"_id" => n, "host" => "#{members[n]['fqdn']}:#{port}"}
+      config["arbiterOnly"] = true  if members[n]['mongodb']['arbiter']
+      rs_members << config
     end
 
-    
     Chef::Log.info(
       "Configuring replicaset with members #{members.collect{ |n| n['hostname'] }.join(', ')}"
     )
-    
+
     rs_member_ips = []
     members.each_index do |n|
       port = members[n]['mongodb']['port']
       rs_member_ips << {"_id" => n, "host" => "#{members[n]['ipaddress']}:#{port}"}
     end
-    
+
     admin = connection['admin']
     cmd = BSON::OrderedHash.new
     cmd['replSetInitiate'] = {
         "_id" => name,
         "members" => rs_members
     }
-    
+
     begin
       result = admin.command(cmd, :check_response => false)
     rescue Mongo::OperationTimeout
@@ -100,7 +107,7 @@ class Chef::ResourceDefinitionList::MongoDB
         end
         config['members'].collect!{ |m| {"_id" => m["_id"], "host" => mapping[m["host"]]} }
         config['version'] += 1
-        
+
         rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
         admin = rs_connection['admin']
         cmd = BSON::OrderedHash.new
@@ -123,20 +130,20 @@ class Chef::ResourceDefinitionList::MongoDB
         rs_members.collect!{ |member| member['host'] }
         config['version'] += 1
         old_members = config['members'].collect{ |member| member['host'] }
-        members_delete = old_members - rs_members        
+        members_delete = old_members - rs_members
         config['members'] = config['members'].delete_if{ |m| members_delete.include?(m['host']) }
         members_add = rs_members - old_members
         members_add.each do |m|
           max_id += 1
           config['members'] << {"_id" => max_id, "host" => m}
         end
-        
+
         rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
         admin = rs_connection['admin']
-        
+
         cmd = BSON::OrderedHash.new
         cmd['replSetReconfig'] = config
-        
+
         result = nil
         begin
           result = admin.command(cmd, :check_response => false)
@@ -154,14 +161,14 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.error("Failed to configure replicaset, reason: #{result.inspect}")
     end
   end
-  
+
   def self.configure_shards(node, shard_nodes)
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     shard_groups = Hash.new{|h,k| h[k] = []}
-    
+
     shard_nodes.each do |n|
       if n['recipes'].include?('mongodb::replicaset')
         key = "rs_#{n['mongodb']['shard_name']}"
@@ -171,7 +178,7 @@ class Chef::ResourceDefinitionList::MongoDB
       shard_groups[key] << "#{n['fqdn']}:#{n['mongodb']['port']}"
     end
     Chef::Log.info(shard_groups.inspect)
-    
+
     shard_members = []
     shard_groups.each do |name, members|
       if name == "_single"
@@ -181,16 +188,16 @@ class Chef::ResourceDefinitionList::MongoDB
       end
     end
     Chef::Log.info(shard_members.inspect)
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
     rescue Exception => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
       return
     end
-    
+
     admin = connection['admin']
-    
+
     shard_members.each do |shard|
       cmd = BSON::OrderedHash.new
       cmd['addShard'] = shard
@@ -202,24 +209,24 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.info(result.inspect)
     end
   end
-  
+
   def self.configure_sharded_collections(node, sharded_collections)
     # lazy require, to move loading this modules to runtime of the cookbook
     require 'rubygems'
     require 'mongo'
-    
+
     begin
       connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5)
     rescue Exception => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason #{e}")
       return
     end
-    
+
     admin = connection['admin']
-    
+
     databases = sharded_collections.keys.collect{ |x| x.split(".").first}.uniq
     Chef::Log.info("enable sharding for these databases: '#{databases.inspect}'")
-    
+
     databases.each do |db_name|
       cmd = BSON::OrderedHash.new
       cmd['enablesharding'] = db_name
@@ -241,7 +248,7 @@ class Chef::ResourceDefinitionList::MongoDB
         Chef::Log.info("Enabled sharding for database '#{db_name}'")
       end
     end
-    
+
     sharded_collections.each do |name, key|
       cmd = BSON::OrderedHash.new
       cmd['shardcollection'] = name
@@ -264,7 +271,7 @@ class Chef::ResourceDefinitionList::MongoDB
         Chef::Log.info("Sharding for collection '#{result['collectionsharded']}' enabled")
       end
     end
-  
+
   end
-  
+
 end


### PR DESCRIPTION
Support for Arbiters via setting a node[:mongodb][:arbiter] = true and minimal changes to the existing replica set configuration.  Supercedes pulls #40 and #47, and incorporates the fix requested in pull #85.

Note that a limit of 1 arbiter per replica set is enforced with this change.
