### PR TITLE
Replicaset duplicate node fix

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -45,7 +45,7 @@ class Chef::ResourceDefinitionList::MongoDB
     end
     
     # Want the node originating the connection to be included in the replicaset
-    members << node unless members.include?(node)
+    members << node if ( members.select{|member| member['fqdn'] == node['fqdn'] }.length == 0)
     members.sort!{ |x,y| x.name <=> y.name }
     rs_members = []
     members.each_index do |n|


### PR DESCRIPTION
The replicaset recipe was attempting to configure mongo with duplicate nodes. This is because the library was failing to successfully check that the node was already in its list of members. This fix overcomes this by not comparing node objects with members but only comparing the fqdn of the node object with members. 
