### PR TITLE
Adding support for chef_gem wihch is available for newer versions of chef

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,14 +23,21 @@ package node[:mongodb][:package_name] do
   action :install
 end
 
-needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))
+needs_mongo_gem = (node.recipes.include?("mongodb::replicaset") or node.recipes.include?("mongodb::mongos"))
 
+# install the mongo ruby gem at compile time to make it globally available
 if needs_mongo_gem
-  # install the mongo ruby gem at compile time to make it globally available
-  gem_package 'mongo' do
-    action :nothing
-  end.run_action(:install)
-  Gem.clear_paths
+  current_version = Gem::Version.new(Chef::VERSION)
+  if(current_version < Gem::Version.new('10.12.0'))
+    gem_package 'mongo' do
+      action :nothing
+    end.run_action(:install)
+    Gem.clear_paths
+  else
+    chef_gem 'mongo' do
+      action :install
+    end
+  end
 end
 
 if node.recipe?("mongodb::default") or node.recipe?("mongodb")


### PR DESCRIPTION
Adding forwards compatibility support for installing "mongo" gem via chef_gem. The cookbook could sometimes error with later versions of chef as the gem was not being installed correctly. 
