### PR TITLE
Replset arg fix

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -101,7 +101,7 @@ class Chef::ResourceDefinitionList::MongoDB
         config['members'].collect!{ |m| {"_id" => m["_id"], "host" => mapping[m["host"]]} }
         config['version'] += 1
         
-        rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
+        rs_connection = Mongo::ReplSetConnection.new(old_members)
         admin = rs_connection['admin']
         cmd = BSON::OrderedHash.new
         cmd['replSetReconfig'] = config

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -43,7 +43,7 @@ class Chef::ResourceDefinitionList::MongoDB
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
       return
     end
-    
+
     # Want the node originating the connection to be included in the replicaset
     members << node unless members.include?(node)
     members.sort!{ |x,y| x.name <=> y.name }
@@ -130,8 +130,8 @@ class Chef::ResourceDefinitionList::MongoDB
           max_id += 1
           config['members'] << {"_id" => max_id, "host" => m}
         end
-        
-        rs_connection = Mongo::ReplSetConnection.new( *old_members.collect{ |m| m.split(":") })
+
+        rs_connection = Mongo::ReplSetConnection.new(old_members)
         admin = rs_connection['admin']
         
         cmd = BSON::OrderedHash.new


### PR DESCRIPTION
Changed the way that Mongo::ReplSetConnection.new is called from the mongodb library. The arguments didn't match those needed for the mongo gem (v 1.8.3)
