### PR TITLE
Fix Package name for ubuntu + a hack

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,12 @@ when "centos","redhat","fedora","amazon","scientific"
   default[:mongodb][:group] = "mongod"
   default[:mongodb][:init_script_template] = "redhat-mongodb.init.erb"
 
+when "ubuntu"
+  default[:mongodb][:defaults_dir] = "/etc/default"
+  default[:mongodb][:root_group] = "root"
+  default[:mongodb][:package_name] = "mongodb"
+  default[:mongodb][:apt_repo] = "debian-sysvinit"
+
 else
   default[:mongodb][:defaults_dir] = "/etc/default"
   default[:mongodb][:root_group] = "root"
@@ -62,3 +68,6 @@ else
   default[:mongodb][:apt_repo] = "debian-sysvinit"
 
 end
+
+# packaging choice
+default[:mongodb][:install_method] = "package"

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -150,10 +150,6 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     if type == "mongos" && node['mongodb']['auto_configure']['sharding']
       notifies :create, "ruby_block[config_sharding]", :immediately
     end
-    if name == "mongodb"
-      # we don't care about a running mongodb service in these cases, all we need is stopping it
-      ignore_failure true
-    end
   end
   
   # replicaset

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -39,6 +39,9 @@ when "debian"
     notifies :run, "execute[apt-get update]", :immediately
   end
 
+  # package name changes
+  node[:mongodb][:package_name] = 'mongo-10gen-server'
+
 when "rhel","fedora"
   yum_repository "10gen" do
     description "10gen RPM Repository"
@@ -48,4 +51,9 @@ when "rhel","fedora"
 
 else
     Chef::Log.warn("Adding the #{node['platform']} 10gen repository is not yet not supported by this cookbook")
+    if node['platform'] == 'freebsd'
+        node[:mongodb][:package_name] = 'mongodb'
+    else
+        node[:mongodb][:package_name] = 'mongodb-10gen'
+    end
 end

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -40,7 +40,7 @@ when "debian"
   end
 
   # package name changes
-  node[:mongodb][:package_name] = 'mongo-10gen-server'
+  node[:mongodb][:package_name] = 'mongodb-10gen'
 
 when "rhel","fedora"
   yum_repository "10gen" do

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -40,7 +40,7 @@ when "debian"
   end
 
   # package name changes
-  node[:mongodb][:package_name] = 'mongodb-10gen'
+  node.default[:mongodb][:package_name] = 'mongodb-10gen'
 
 when "rhel","fedora"
   yum_repository "10gen" do
@@ -52,8 +52,8 @@ when "rhel","fedora"
 else
     Chef::Log.warn("Adding the #{node['platform']} 10gen repository is not yet not supported by this cookbook")
     if node['platform'] == 'freebsd'
-        node[:mongodb][:package_name] = 'mongodb'
+        node.default[:mongodb][:package_name] = 'mongodb'
     else
-        node[:mongodb][:package_name] = 'mongodb-10gen'
+        node.default[:mongodb][:package_name] = 'mongodb-10gen'
     end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,8 +31,8 @@ end
 # this is a hack to deal with ubuntu install upstart script
 # and because we don't want to maintain more init scripts
 if node['platform'] == 'ubuntu' and node['mongodb']['install_method'] == 'package' then
-    bash 'remove upstart file' do
-        command 'rm /etc/init/mongodb.conf'
+    execute 'remove upstart file' do
+        command 'stop mongodb && rm /etc/init/mongodb.conf'
         action :run
         only_if 'test -f /etc/init/mongodb.conf'
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,17 @@ package node[:mongodb][:package_name] do
   action :install
 end
 
+# this is a hack to deal with ubuntu install upstart script
+# and because we don't want to maintain more init scripts
+if node['platform'] == 'ubuntu' and node['mongodb']['install_method'] == 'package' then
+    bash 'remove upstart file' do
+        command 'rm /etc/init/mongodb.conf'
+        action :run
+        only_if 'test -f /etc/init/mongodb.conf'
+    end
+end
+# end hack
+
 needs_mongo_gem = (node.recipe?("mongodb::replicaset") or node.recipe?("mongodb::mongos"))
 
 if needs_mongo_gem

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,11 @@
 # limitations under the License.
 #
 
+case node[:mongodb][:install_method]
+when '10gen'
+    include_recipe "mongodb::10gen_repo"
+end
+
 package node[:mongodb][:package_name] do
   action :install
 end


### PR DESCRIPTION
supercede #51 #36 
1. Fixes package names such that cookbook user can use the attributes to control installation
2. Fixes ubuntu package name to close issues like #86 #46  etc.
3. adds a **hack**
#### hack

Due to ubuntu using upstart, I added a hack in `mongodb::default` that would stop the mongo server (if the upstart file is found) and remove the said upstart file.  The hack should only ever run once (unless something keeps recreating the upstart file).

Ubuntu users who are using the cookbooks will not be affected since they have been installing via the `mongodb::10gen` which would not have used the upstart file.

I think the only reasonable `clean` alternative would be to add the ubuntu upstart file into templates, but it would need a reworking of the mongod definition, so it would have to wait for now.
