### PR TITLE
add minimal tests. Fixes #114

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,37 @@
+---
+driver_plugin: vagrant
+driver_config:
+  require_chef_omnibus: true
+
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    box: opscode-ubuntu-12.04
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
+  run_list:
+  - "recipe[apt]"
+- name: ubuntu-10.04
+  driver_config:
+    box: opscode-ubuntu-10.04
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
+  run_list:
+  - "recipe[apt]"
+- name: centos-6.4
+  driver_config:
+    box: opscode-centos-6.4
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
+  run_list:
+  - "recipe[yum]"
+- name: centos-5.9
+  driver_config:
+    box: opscode-centos-5.9
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
+  run_list:
+  - "recipe[yum]"
+
+suites:
+- name: default
+  run_list:
+  - "recipe[mongodb::10gen_repo]"
+  - "recipe[mongodb]"
+  attributes: {}

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+site :opscode
+
+metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,16 @@
+{
+  "sha": "6ef716553a56267bb3eb743ece483db8aa94cecb",
+  "sources": {
+    "mongodb": {
+      "locked_version": "0.12.0",
+      "constraint": "= 0.12.0",
+      "path": "."
+    },
+    "apt": {
+      "locked_version": "1.6.1"
+    },
+    "yum": {
+      "locked_version": "2.0.6"
+    }
+  }
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+# gem 'berkshelf' # use head until stable includes lockfile 2.0 support
+gem 'berkshelf', :github => 'RiotGames/berkshelf'
+
+group :integration do
+  gem 'kitchen-vagrant', :github => 'opscode/kitchen-vagrant'
+  gem 'test-kitchen', :github => 'opscode/test-kitchen'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,145 @@
+GIT
+  remote: git://github.com/RiotGames/berkshelf.git
+  revision: 4812c3dd100b0ff0b558637551d7b50bc9f53b67
+  specs:
+    berkshelf (2.0.0.beta)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.3.4)
+      celluloid (>= 0.14.0)
+      chozo (>= 0.6.1)
+      faraday (>= 0.8.5)
+      hashie (>= 2.0.2)
+      minitar (~> 0.5.4)
+      mixlib-config (~> 1.1)
+      mixlib-shellout (~> 1.1)
+      retryable (~> 1.3.3)
+      ridley (~> 0.12.1)
+      solve (>= 0.4.4)
+      test-kitchen (>= 1.0.0.alpha6)
+      thor (~> 0.18.0)
+
+GIT
+  remote: git://github.com/opscode/kitchen-vagrant.git
+  revision: 4742374f7fb0d04cb3bf35be26cf54d152610b33
+  specs:
+    kitchen-vagrant (0.10.1.dev)
+      test-kitchen (~> 1.0.0.alpha.6)
+
+GIT
+  remote: git://github.com/opscode/test-kitchen.git
+  revision: 6e5041194ca5759dacbf74813fb4a37b3b579736
+  specs:
+    test-kitchen (1.0.0.dev)
+      celluloid
+      mixlib-shellout
+      net-scp
+      net-ssh
+      pry
+      safe_yaml
+      thor
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
+      multi_json (~> 1.0)
+    addressable (2.3.4)
+    akami (1.2.0)
+      gyoku (>= 0.4.0)
+      nokogiri (>= 1.4.0)
+    builder (3.2.0)
+    celluloid (0.14.0)
+      timers (>= 1.0.0)
+    chozo (0.6.1)
+      activesupport (>= 3.2.0)
+      hashie (>= 2.0.2)
+      multi_json (>= 1.3.0)
+    coderay (1.0.9)
+    erubis (2.7.0)
+    faraday (0.8.7)
+      multipart-post (~> 1.1)
+    ffi (1.8.1)
+    gssapi (1.0.3)
+      ffi (>= 1.0.1)
+    gyoku (1.0.0)
+      builder (>= 2.1.2)
+    hashie (2.0.5)
+    httpclient (2.2.0.2)
+    httpi (0.9.7)
+      rack
+    i18n (0.6.1)
+    json (1.8.0)
+    little-plugger (1.1.3)
+    logging (1.6.2)
+      little-plugger (>= 1.1.3)
+    method_source (0.8.1)
+    minitar (0.5.4)
+    mixlib-authentication (1.3.0)
+      mixlib-log
+    mixlib-config (1.1.2)
+    mixlib-log (1.6.0)
+    mixlib-shellout (1.1.0)
+    multi_json (1.7.4)
+    multipart-post (1.2.0)
+    net-http-persistent (2.8)
+    net-scp (1.1.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.6.7)
+    nokogiri (1.5.9)
+    nori (1.1.5)
+    pry (0.9.12.2)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
+    rack (1.5.2)
+    retryable (1.3.3)
+    ridley (0.12.3)
+      addressable
+      celluloid (~> 0.14.0)
+      chozo (>= 0.6.0)
+      erubis
+      faraday (>= 0.8.4)
+      mixlib-authentication (>= 1.3.0)
+      mixlib-config (>= 1.1.0)
+      mixlib-log (>= 1.3.0)
+      mixlib-shellout (>= 1.1.0)
+      net-http-persistent (>= 2.8)
+      net-ssh
+      retryable
+      solve (>= 0.4.4)
+      winrm (~> 1.1.0)
+    rubyntlm (0.1.1)
+    safe_yaml (0.9.1)
+    savon (0.9.5)
+      akami (~> 1.0)
+      builder (>= 2.1.2)
+      gyoku (>= 0.4.0)
+      httpi (~> 0.9)
+      nokogiri (>= 1.4.0)
+      nori (~> 1.0)
+      wasabi (~> 1.0)
+    slop (3.4.5)
+    solve (0.4.4)
+      json
+    thor (0.18.1)
+    timers (1.1.0)
+    uuidtools (2.1.4)
+    wasabi (1.0.0)
+      nokogiri (>= 1.4.0)
+    winrm (1.1.2)
+      gssapi (~> 1.0.0)
+      httpclient (~> 2.2.0.2)
+      logging (~> 1.6.1)
+      nokogiri (~> 1.5.0)
+      rubyntlm (~> 0.1.1)
+      savon (= 0.9.5)
+      uuidtools (~> 2.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  berkshelf!
+  kitchen-vagrant!
+  test-kitchen!

--- a/test/integration/default/bats/default.bats
+++ b/test/integration/default/bats/default.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "starts mongodb" {
+  # should return a 0 status code if mongodb is running
+  /etc/init.d/mongodb status
+}


### PR DESCRIPTION
Using test-kichen and BATS, this verifies that a run list of
["recipe[mongodb::10gen_repo]","recipe[mongodb::default]"] correctly
starts the mongodb service on Ubuntu 10.04, 12.04 and CentOS 5.9, 6.4.

Testing can be performed by running

```
bundle install
bundle exec berks install
bundle exec kitchen test --parallel
```
