### PR TITLE
Sort Config Server Connection String

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -80,7 +80,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   else
     daemon = "/usr/bin/mongos"
     dbpath = nil
-    configserver = configserver_nodes.collect{|n| "#{n['fqdn']}:#{n['mongodb']['port']}" }.join(",")
+    configserver = configserver_nodes.collect{|n| "#{n['fqdn']}:#{n['mongodb']['port']}" }.sort.join(",")
   end
   
   # default file


### PR DESCRIPTION
The order of the config servers in the mongos connection string is important-- it must match across all instances of mongos and the value cached(?) at the config server.  This is a simple change to sort config servers to ensure consistency across chef runs.

Important!  This is a breaking change for anyone who's config servers aren't already in order.   If the config strings don't match, the mongos instance will not connect to the config server.  To update to the new sorted strings, it appears you need to stop the cluster and restart it to pickup the new config.

https://jira.mongodb.org/browse/SERVER-5960
