### PR TITLE
Make metadata.rb more compliant

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -37,6 +37,7 @@ attribute "mongodb/port",
 attribute "mongodb/client_roles",
   :display_name => "Client Roles",
   :description => "Roles of nodes who need access to the mongodb instance",
+  :type => "array",
   :default => []
 
 attribute "mongodb/cluster_name",
@@ -52,7 +53,8 @@ attribute "mongodb/shard_name",
 attribute "mongodb/sharded_collections",
   :display_name => "Sharded Collections",
   :description => "collections to shard",
-  :default => {}
+  :type => "array",
+  :default => nil
 
 attribute "mongodb/replicaset_name",
   :display_name => "Replicaset_name",

--- a/metadata.rb
+++ b/metadata.rb
@@ -54,7 +54,7 @@ attribute "mongodb/sharded_collections",
   :display_name => "Sharded Collections",
   :description => "collections to shard",
   :type => "array",
-  :default => nil
+  :default => []
 
 attribute "mongodb/replicaset_name",
   :display_name => "Replicaset_name",


### PR DESCRIPTION
Make metadata.rb more compliant - only string or array types are supported; default cannot be a hash.
