### PR TITLE
updated (very outdated) apt dependency to allow more recent versions

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,17 +1,14 @@
 {
-  "sha": "6ef716553a56267bb3eb743ece483db8aa94cecb",
   "sources": {
     "mongodb": {
-      "locked_version": "0.12.0",
-      "constraint": "~> 0.12.0",
       "path": "."
     },
     "apt": {
-      "locked_version": "1.4.8",
-      "constraint": "~> 1.4.4"
+      "locked_version": "1.8.4",
+      "constraint": ">= 1.8.2"
     },
     "yum": {
-      "locked_version": "2.2.2"
+      "locked_version": "2.1.0"
     }
   }
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe "mongodb::configserver", "Installs and configures a configserver for mong
 recipe "mongodb::shard", "Installs and configures a single shard"
 recipe "mongodb::replicaset", "Installs and configures a mongodb replicaset"
 
-depends "apt", "~> 1.4.4"
+depends "apt", ">= 1.8.2"
 depends "yum"
 
 %w{ ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|


### PR DESCRIPTION
The real important thing is that there is a major bug in versions of the apt cookbook south of 1.8.2 (specifically [COOK-2171](https://github.com/opscode-cookbooks/apt/blob/master/CHANGELOG.md#v182)), but the original restriction also doesn't allow anything close to recent.
