### PR TITLE
removed recipe check from auto-configure to support wrapper cookbooks

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -165,7 +165,6 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     rs_nodes = search(
       :node,
       "mongodb_cluster_name:#{replicaset['mongodb']['cluster_name']} AND \
-       recipes:mongodb\\:\\:replicaset AND \
        mongodb_shard_name:#{replicaset['mongodb']['shard_name']} AND \
        chef_environment:#{replicaset.chef_environment}"
     )
@@ -188,7 +187,6 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
     shard_nodes = search(
       :node,
       "mongodb_cluster_name:#{node['mongodb']['cluster_name']} AND \
-       recipes:mongodb\\:\\:shard AND \
        chef_environment:#{node.chef_environment}"
     )
     


### PR DESCRIPTION
explicitly checking for recipes in the run-list during auto-configuration limits the ability to wrap the cookbook and/or include it conditionally from a recipe. i've removed that portion of the node search.
