### PR TITLE
mongos does not support enable_rest, so don't set --rest for it.

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -104,7 +104,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       "configsrv" => false, #type == "configserver", this might change the port
       "shardsrv" => false,  #type == "shard", dito.
       "nojournal" => nojournal,
-      "enable_rest" => params[:enable_rest],
+      "enable_rest" => params[:enable_rest] && type != "mongos",
       "smallfiles" => params[:smallfiles]
     )
     notifies :restart, "service[#{name}]"


### PR DESCRIPTION
Do not allow it to be applied, in case enable_rest is turned on for all nodes or as a default attribute setting. Otherwise mongos won't start.
