### PR TITLE
Add ability to use a config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 .kitchen/
 .kitchen.local.yml
+Vagrantfile

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,6 +48,9 @@ default[:mongodb][:ulimit][:open_files] = 64000
 default[:mongodb][:ulimit][:memory_size] = "unlimited"
 default[:mongodb][:ulimit][:processes] = 32000
 
+# other settings
+default[:mongodb][:oplogsize] = nil
+
 default[:mongodb][:init_dir] = "/etc/init.d"
 
 default[:mongodb][:init_script_template] = "mongodb.init.erb"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,3 +76,11 @@ end
 default[:mongodb][:package_version] = nil
 default[:mongodb][:nojournal] = false
 default[:mongodb][:template_cookbook] = "mongodb"
+
+# missing options from config file
+default[:mongodb][:use_configfile] = false
+default[:mongodb][:logappend] = true
+default[:mongodb][:cpu] = true
+default[:mongodb][:noauth] = true
+default[:mongodb][:auth] = true
+

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,8 @@ default[:mongodb][:dbpath] = "/var/lib/mongodb"
 default[:mongodb][:logpath] = "/var/log/mongodb"
 default[:mongodb][:bind_ip] = nil
 default[:mongodb][:port] = 27017
-default[:mongodb][:configfile] = nil
+default[:mongodb][:use_configfile] = false
+default[:mongodb][:configfile] = "/etc/mongodb.conf"
 
 # cluster identifier
 default[:mongodb][:client_roles] = []
@@ -76,11 +77,3 @@ end
 default[:mongodb][:package_version] = nil
 default[:mongodb][:nojournal] = false
 default[:mongodb][:template_cookbook] = "mongodb"
-
-# missing options from config file
-default[:mongodb][:use_configfile] = false
-default[:mongodb][:logappend] = true
-default[:mongodb][:cpu] = true
-default[:mongodb][:noauth] = true
-default[:mongodb][:auth] = true
-

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -39,7 +39,8 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
 
   dbpath = params[:dbpath]
 
-  configfile = if node['mongodb']['configfile'].nil? then "/etc/mongodb.conf" else node['mongodb']['configfile'] end
+  configfile = node[:mongodb][:configfile]
+
   configserver_nodes = params[:configserver]
 
   replicaset = params[:replicaset]

--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -1,0 +1,92 @@
+# mongodb.conf
+#
+# # Where to store the data.
+#
+# # Note: if you run mongodb as a non-root user (recommended) you may
+# # need to create and set permissions for this directory manually,
+# # e.g., if the parent directory isn't mutable by the mongodb user.
+dbpath=<%= @mongodb[:dbpath] %>
+#
+# #where to log
+logpath=<%= "#{@mongodb[:logpath]}/mongodb.log" %>
+#
+logappend=<%= @mongodb[:logappend] %>
+#
+port = <%= @mongodb[:port] %>
+#
+# Disables write-ahead journaling
+#nojournal = <%= @mongodb[:nojournal] %>
+#
+# Enables periodic logging of CPU utilization and I/O wait
+#cpu = <%= @mongodb[:cpu] %>
+#
+# Turn on/off security.  Off is currently the default
+#noauth = <%= @mongodb[:noauth] %>
+#auth = <%= @mongodb[:auth] %>
+#
+# # Verbose logging output.
+# #verbose = true
+#
+# # Inspect all client data for validity on receipt (useful for
+# # developing drivers)
+# #objcheck = true
+#
+# # Enable db quota management
+# #quota = true
+#
+# # Set oplogging level where n is
+# #   0=off (default)
+# #   1=W
+# #   2=R
+# #   3=both
+# #   7=W+some reads
+# #diaglog = 0
+#
+# # Ignore query hints
+# #nohints = true
+#
+# # Disable the HTTP interface (Defaults to localhost:28017).
+# #nohttpinterface = true
+#
+# # Turns off server-side scripting.  This will result in greatly limited
+# # functionality
+# #noscripting = true
+#
+# # Turns off table scans.  Any query that would do a table scan fails.
+# #notablescan = true
+#
+# # Disable data file preallocation.
+# #noprealloc = true
+#
+# # Specify .ns file size for new databases.
+# # nssize = <size>
+#
+# # Accout token for Mongo monitoring server.
+# #mms-token = <token>
+#
+# # Server name for Mongo monitoring server.
+# #mms-name = <server-name>
+#
+# # Ping interval for Mongo monitoring server.
+# #mms-interval = <seconds>
+#
+# # Replication Options
+#
+# # in master/slave replicated mongo databases, specify here whether
+# # this is a slave or master
+# #slave = true
+# #source = master.example.com
+# # Slave only: specify a single database to replicate
+# #only = master.example.com
+# # or
+# #master = true
+# #source = slave.example.com
+#
+# # in replica set configuration, specify the name of the replica set
+#
+<% if @mongodb[:replicaset_name] %>
+# replSet = setname
+<% else %>
+replSet = <%= @mongodb[:replicaset_name] %>
+<% end %>
+

--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -85,8 +85,8 @@ port = <%= @mongodb[:port] %>
 # # in replica set configuration, specify the name of the replica set
 #
 <% if @mongodb[:replicaset_name] %>
-# replSet = setname
-<% else %>
 replSet = <%= @mongodb[:replicaset_name] %>
+<% else %>
+# replSet = setname
 <% end %>
 

--- a/templates/default/mongodb.conf.erb
+++ b/templates/default/mongodb.conf.erb
@@ -1,92 +1,96 @@
 # mongodb.conf
 #
-# # Where to store the data.
+# Where to store the data.
 #
-# # Note: if you run mongodb as a non-root user (recommended) you may
-# # need to create and set permissions for this directory manually,
-# # e.g., if the parent directory isn't mutable by the mongodb user.
+# Note: if you run mongodb as a non-root user (recommended) you may
+# need to create and set permissions for this directory manually,
+# e.g., if the parent directory isn't mutable by the mongodb user.
 dbpath=<%= @mongodb[:dbpath] %>
-#
-# #where to log
+
+#where to log
 logpath=<%= "#{@mongodb[:logpath]}/mongodb.log" %>
-#
+
 logappend=<%= @mongodb[:logappend] %>
-#
+
 port = <%= @mongodb[:port] %>
-#
+
 # Disables write-ahead journaling
 #nojournal = <%= @mongodb[:nojournal] %>
-#
+
 # Enables periodic logging of CPU utilization and I/O wait
 #cpu = <%= @mongodb[:cpu] %>
-#
+
 # Turn on/off security.  Off is currently the default
 #noauth = <%= @mongodb[:noauth] %>
 #auth = <%= @mongodb[:auth] %>
-#
-# # Verbose logging output.
-# #verbose = true
-#
-# # Inspect all client data for validity on receipt (useful for
-# # developing drivers)
-# #objcheck = true
-#
-# # Enable db quota management
-# #quota = true
-#
-# # Set oplogging level where n is
-# #   0=off (default)
-# #   1=W
-# #   2=R
-# #   3=both
-# #   7=W+some reads
-# #diaglog = 0
-#
-# # Ignore query hints
-# #nohints = true
-#
-# # Disable the HTTP interface (Defaults to localhost:28017).
-# #nohttpinterface = true
-#
-# # Turns off server-side scripting.  This will result in greatly limited
-# # functionality
-# #noscripting = true
-#
-# # Turns off table scans.  Any query that would do a table scan fails.
-# #notablescan = true
-#
-# # Disable data file preallocation.
-# #noprealloc = true
-#
-# # Specify .ns file size for new databases.
-# # nssize = <size>
-#
-# # Accout token for Mongo monitoring server.
-# #mms-token = <token>
-#
-# # Server name for Mongo monitoring server.
-# #mms-name = <server-name>
-#
-# # Ping interval for Mongo monitoring server.
-# #mms-interval = <seconds>
-#
-# # Replication Options
-#
-# # in master/slave replicated mongo databases, specify here whether
-# # this is a slave or master
-# #slave = true
-# #source = master.example.com
-# # Slave only: specify a single database to replicate
-# #only = master.example.com
-# # or
-# #master = true
-# #source = slave.example.com
-#
-# # in replica set configuration, specify the name of the replica set
-#
+
+# Verbose logging output.
+#verbose = true
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+#diaglog = 0
+<% if @mongodb[:oplogsize] %>
+oplogSize = <% @mongodb[:oplogsize] %>
+<% end -%>
+
+# Ignore query hints
+#nohints = true
+
+# Disable the HTTP interface (Defaults to localhost:28017).
+#nohttpinterface = true
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation.
+#noprealloc = true
+
+# Specify .ns file size for new databases.
+# nssize = <size>
+
+# Accout token for Mongo monitoring server.
+#mms-token = <token>
+
+# Server name for Mongo monitoring server.
+#mms-name = <server-name>
+
+# Ping interval for Mongo monitoring server.
+#mms-interval = <seconds>
+
+# Replication Options
+
+# in master/slave replicated mongo databases, specify here whether
+# this is a slave or master
+#slave = true
+#source = master.example.com
+# Slave only: specify a single database to replicate
+#only = master.example.com
+# or
+#master = true
+#source = slave.example.com
+
+# in replica set configuration, specify the name of the replica set
 <% if @mongodb[:replicaset_name] %>
 replSet = <%= @mongodb[:replicaset_name] %>
-<% else %>
+<% else -%>
 # replSet = setname
-<% end %>
+<% end -%>
+
+
 

--- a/templates/default/mongodb.default.erb
+++ b/templates/default/mongodb.default.erb
@@ -6,6 +6,7 @@ NAME="<%= @name %>"
 
 DAEMON_OPTS=""
 
+<% unless @use_configfile -%>
 <% if @bind_ip -%>
 DAEMON_OPTS="$DAEMON_OPTS --bind_ip <%= @bind_ip %>"
 <% end -%>
@@ -37,3 +38,7 @@ DAEMON_OPTS="$DAEMON_OPTS --smallfiles"
 DAEMON_OPTS="$DAEMON_OPTS --fork"
 DBPATH="<%= @dbpath %>"
 <% end -%>
+<% else %>
+<%= @config ? "DAEMON_OPTS=\"$DAEMON_OPTS --config #{@config}\"" : "" %>
+<% end -%>
+

--- a/templates/default/mongodb.init.erb
+++ b/templates/default/mongodb.init.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 ### BEGIN INIT INFO
 # Provides:          <%= @provides %>
@@ -34,7 +34,7 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DESC=database
 DAEMON=/usr/bin/mongod
-DAEMON_OPTS="--config /etc/mongodb.conf"
+DAEMON_OPTS="--config <%= @configfile %>"
 
 ENABLE_MONGODB=yes
 


### PR DESCRIPTION
These commits focus entirely on enabling the user to use a config file, and offer more fine grained control over those aspects of their mongo instance.

Simply provide a role like this in your Vagrantfile/roles

``` ruby
:mongodb =>  
{
  :dbpath => "/for/the/luls",
  :package_version => "2.4.4",
  :use_configfile => true
}
```

or override 

``` ruby
# in your new recipe
node.override[:mongodb][:use_configfile] = true 
```

Also, you can set the config file name, and location like so:

``` ruby
# in your recipe, or override in a role
node.override[:mongodb][:configfile] = "/etc/non_standard_mongo.conf"
```
