### PR TITLE
Replicasets configuration fixes and some small small tweaks around error handling and displaying

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -38,13 +38,13 @@ class Chef::ResourceDefinitionList::MongoDB
     end
 
     begin
-      connection = nil
-      rescue_connection_failure do
-        connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
-        connection.database_names # check connection
-      end
-    rescue
-      Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}'")
+	  connection = nil
+	  rescue_connection_failure do
+	    connection = Mongo::Connection.new('localhost', node['mongodb']['port'], :op_timeout => 5, :slave_ok => true)
+	    connection.database_names # check connection
+	  end
+    rescue Exception => e
+      Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['port']}', reason: #{e}")
       return
     end
 

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -133,7 +133,7 @@ class Chef::ResourceDefinitionList::MongoDB
           config = connection['local']['system']['replset'].find_one({"_id" => name})
           Chef::Log.info("New config successfully applied: #{config.inspect}")
         end
-        if !result.nil?
+        if !result.fetch("errmsg", nil).nil?
           Chef::Log.error("configuring replicaset returned: #{result.inspect}")
         end
       else
@@ -170,7 +170,7 @@ class Chef::ResourceDefinitionList::MongoDB
           config = connection['local']['system']['replset'].find_one({"_id" => name})
           Chef::Log.info("New config successfully applied: #{config.inspect}")
         end
-        if !result.nil?
+        if !result.fetch("errmsg", nil).nil?
           Chef::Log.error("configuring replicaset returned: #{result.inspect}")
         end
       end


### PR DESCRIPTION
I've made 4 separate commits to fix the following issues:
- The 3rd replica could not be added to a sharded replica set, because the previous nodes have already been initiated.
- Error display fix (not hiding and Exception when it occurs)
- Error checking fixes (errmsg should be checked for error not the full result)
- Added an attribute to specify the wait for the mongod instance to start at the first time to be able to handle preallocation lag
