### PR TITLE
Add recipe-tester.com support

### DIFF
--- a/.recipe-tester.json
+++ b/.recipe-tester.json
@@ -3,6 +3,7 @@
     "chef_version": "11.4.4",
     "ami": [
         "ami-e7582d8e", // Ubuntu 12.04
+        "ami-d0f89fb9", // Ubuntu 12.04 32 bit
         "ami-8eadd0e7" // Ubuntu 10.04
     ],
     "run_list": [

--- a/.recipe-tester.json
+++ b/.recipe-tester.json
@@ -1,0 +1,16 @@
+{
+    "type": "chef-solo",
+    "chef_version": "11.4.4",
+    "ami": [
+        "ami-e7582d8e", // Ubuntu 12.04
+        "ami-8eadd0e7" // Ubuntu 10.04
+    ],
+    "run_list": [
+        "recipe[mongodb::10gen_repo]",
+        "recipe[mongodb::default]"
+    ],
+    "node_attributes": {
+        "dbpath": "/var/log/mongodb"
+    }
+}
+

--- a/.recipe-tester.json
+++ b/.recipe-tester.json
@@ -4,7 +4,9 @@
     "ami": [
         "ami-e7582d8e", // Ubuntu 12.04
         "ami-d0f89fb9", // Ubuntu 12.04 32 bit
-        "ami-8eadd0e7" // Ubuntu 10.04
+        "ami-7d317314", // Ubuntu 13.04
+        "ami-bab10ad3", // Ubuntu 11.04
+        "ami-8eadd0e7", // Ubuntu 10.04
     ],
     "run_list": [
         "recipe[mongodb::10gen_repo]",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://recipe-tester.com/repo/edelight/chef-mongodb/badge.png)](https://recipe-tester.com/repo/edelight/chef-mongodb/)
+
 # DESCRIPTION:
 
 Installs and configures MongoDB, supporting:


### PR DESCRIPTION
This adds a configuration file for [Recipe Tester](https://www.recipe-tester.com). Recipe Tester is a hosted continuous integration system for Chef cookbooks. It's like Travis-CI, but for Chef cookbooks.

You'll also need to add a Github post-receive hook for this to work. More info in the [docs](http://docs.recipe-tester.com/).

I've only added the two Ubuntu AMIs for now since I'm having some issues with the CentOS ones, but that will hopefully be solved soon.

The build that my fork is running on can be found [here](https://www.recipe-tester.com/repo/spulec/chef-mongodb/).

Please let me know if there are any issues or there's anything else I can do to help get this setup.
