### PR TITLE
Remove recipe checks

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,15 +37,13 @@ if node[:mongodb][:key_file]
 end
 
 
-if node.recipe?("mongodb::default") or node.recipe?("mongodb")
-  # configure default instance
-  mongodb_instance "mongodb" do
-    mongodb_type "mongod"
-    bind_ip      node['mongodb']['bind_ip']
-    port         node['mongodb']['port']
-    logpath      node['mongodb']['logpath']
-    dbpath       node['mongodb']['dbpath']
-    enable_rest  node['mongodb']['enable_rest']
-    smallfiles   node['mongodb']['smallfiles']
-  end
+# configure default instance
+mongodb_instance "mongodb" do
+  mongodb_type "mongod"
+  bind_ip      node['mongodb']['bind_ip']
+  port         node['mongodb']['port']
+  logpath      node['mongodb']['logpath']
+  dbpath       node['mongodb']['dbpath']
+  enable_rest  node['mongodb']['enable_rest']
+  smallfiles   node['mongodb']['smallfiles']
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,21 +24,6 @@ package node[:mongodb][:package_name] do
   version node[:mongodb][:package_version]
 end
 
-needs_mongo_gem = (node.recipes.include?("mongodb::replicaset") or node.recipes.include?("mongodb::mongos"))
-
-# install the mongo ruby gem at compile time to make it globally available
-if needs_mongo_gem
-  if(Gem.const_defined?("Version") and Gem::Version.new(Chef::VERSION) < Gem::Version.new('10.12.0'))
-    gem_package 'mongo' do
-      action :nothing
-    end.run_action(:install)
-    Gem.clear_paths
-  else
-    chef_gem 'mongo' do
-      action :install
-    end
-  end
-end
 
 # Create keyFile if specified
 if node[:mongodb][:key_file]

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -1,0 +1,11 @@
+# install the mongo ruby gem at compile time to make it globally available
+if(Gem.const_defined?("Version") and Gem::Version.new(Chef::VERSION) < Gem::Version.new('10.12.0'))
+  gem_package 'mongo' do
+    action :nothing
+  end.run_action(:install)
+  Gem.clear_paths
+else
+  chef_gem 'mongo' do
+    action :install
+  end
+end

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -20,6 +20,7 @@
 #
 
 include_recipe "mongodb"
+include_recipe "mongodb::mongo_gem"
 
 service "mongodb" do
   action [:disable, :stop]

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe "mongodb"
+include_recipe "mongodb::mongo_gem"
 
 # if we are configuring a shard as a replicaset we do nothing in this recipe
 if !node.recipe?("mongodb::shard")


### PR DESCRIPTION
Instead of checking to see if recipes are loaded, just run the code in the given recipes.

Doing it the way it was before this change causes issues with wrapping this cookbook.
