### PR TITLE
Don't run mongodb_instance in default recipe for replicaset.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,12 +38,16 @@ end
 
 
 # configure default instance
-mongodb_instance node['mongodb']['instance_name'] do
-  mongodb_type "mongod"
-  bind_ip      node['mongodb']['bind_ip']
-  port         node['mongodb']['port']
-  logpath      node['mongodb']['logpath']
-  dbpath       node['mongodb']['dbpath']
-  enable_rest  node['mongodb']['enable_rest']
-  smallfiles   node['mongodb']['smallfiles']
+recipe = 'mongodb::replicaset'
+new_chef = Chef::Version.new(Chef::VERSION).major >= 11
+if new_chef ? !node.run_context.loaded_recipe?(recipe) : !node.recipe?(recipe)
+  mongodb_instance node['mongodb']['instance_name'] do
+    mongodb_type "mongod"
+    bind_ip      node['mongodb']['bind_ip']
+    port         node['mongodb']['port']
+    logpath      node['mongodb']['logpath']
+    dbpath       node['mongodb']['dbpath']
+    enable_rest  node['mongodb']['enable_rest']
+    smallfiles   node['mongodb']['smallfiles']
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,9 +38,13 @@ end
 
 
 # configure default instance
-recipe = 'mongodb::replicaset'
-new_chef = Chef::Version.new(Chef::VERSION).major >= 11
-if new_chef ? !node.run_context.loaded_recipe?(recipe) : !node.recipe?(recipe)
+replicaset_recipe = 'mongodb::replicaset'
+configured_as_replicaset = case Chef::Version.new(Chef::VERSION).major
+  when 0..10 then node.recipe?(replicaset_recipe)
+  else node.run_context.loaded_recipe?(replicaset_recipe)
+end
+
+unless configured_as_replicaset
   mongodb_instance node['mongodb']['instance_name'] do
     mongodb_type "mongod"
     bind_ip      node['mongodb']['bind_ip']


### PR DESCRIPTION
Fixes #55. Prevents service restart because of unnecessary configuration change. Works when replicaset recipe is included from another recipe. Tested on Chef 10.14.2 (vagrant box http://files.vagrantup.com/precise64.box) and 11.4.0 (http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210.box).
