### PR TITLE
Allow to set replica options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ For examples see the USAGE section below.
 * `mongodb[:shard_name]` - Name of a shard, default is "default"
 * `mongodb[:sharded_collections]` - Define which collections are sharded
 * `mongodb[:replicaset_name]` - Define name of replicaset
+* `mongodb[:replica_arbiter_only]` - Set to true to make node an [arbiter](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].arbiterOnly).
+* `mongodb[:replica_build_indexes]` - Set to false to omit [index creation](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].buildIndexes).
+* `mongodb[:replica_hidden]` - Set to true to [hide](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].hidden) node from replicaset.
+* `mongodb[:replica_slave_delay]` - Number of seconds to [delay slave replication](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].slaveDelay).
+* `mongodb[:replica_priority]` - Node [priority](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].priority).
+* `mongodb[:replica_tags]` - Node [tags](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].tags).
+* `mongodb[:replica_votes]` - Number of [votes](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].votes) node will cast in an election.
 * `mongodb[:package_version]` - Version of the MongoDB package to install, default is nil
 
 # USAGE:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,15 @@ default[:mongodb][:cluster_name] = nil
 default[:mongodb][:replicaset_name] = nil
 default[:mongodb][:shard_name] = "default"
 
+# replica options
+default[:mongodb][:replica_arbiter_only] = false
+default[:mongodb][:replica_build_indexes] = true
+default[:mongodb][:replica_hidden] = false
+default[:mongodb][:replica_slave_delay] = 0
+default[:mongodb][:replica_priority] = 1
+default[:mongodb][:replica_tags] = {}
+default[:mongodb][:replica_votes] = 1
+
 default[:mongodb][:auto_configure][:replicaset] = true
 default[:mongodb][:auto_configure][:sharding] = true
 default[:mongodb][:key_file] = nil


### PR DESCRIPTION
Requires ruby_block[config_replicaset] to run on every chef-client run (#149).
