### PR TITLE
Prevent autostart after installation (Fix #86 Vagrant issue)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -83,6 +83,7 @@ else
   default[:mongodb][:package_name] = "mongodb-10gen"
   default[:mongodb][:apt_repo] = "debian-sysvinit"
   default[:mongodb][:instance_name] = "mongodb"
+  default[:mongodb][:prevent_startup] = false
 
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,12 @@
 # limitations under the License.
 #
 
+file "/etc/default/mongodb" do
+  action :create_if_missing
+  owner "root"
+  content "ENABLE_MONGODB=no"
+end
+
 package node[:mongodb][:package_name] do
   action :install
   version node[:mongodb][:package_version]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,10 +19,16 @@
 # limitations under the License.
 #
 
-file "/etc/default/mongodb" do
-  action :create_if_missing
-  owner "root"
-  content "ENABLE_MONGODB=no"
+if node[:mongodb][:prevent_startup]
+  if node['platform_family'] = "debian"
+    file "/etc/default/mongodb" do
+      action :create_if_missing
+      owner "root"
+      content "ENABLE_MONGODB=no"
+    end
+  else
+    Chef::Log.warn("Mongodb does not support ENABLE_MONGODB option to prevent startup for #{node['platform_family']}.")
+  end
 end
 
 package node[:mongodb][:package_name] do


### PR DESCRIPTION
When provisioning on Vagrant for the first time, mongodb auto starts after installation. Because the virtual box by default has only 4GB storage, it will fail to run mongodb without specifying `nojournal` option. The second provision will be successful because it skips the install part and goes to `mongodb_instance` section where, if `nojournal` is specified in attribute, it knows to apply good configuration and start mongodb. fixes #86
