### PR TITLE
fix for install issues on ubuntu/debian

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,9 +19,24 @@
 # limitations under the License.
 #
 
+# note that this must be called "mongodb"
+# this has been filed as https://tickets.opscode.com/browse/CHEF-4699
+service "mongodb" do
+ action :nothing
+end
+
 package node[:mongodb][:package_name] do
   action :install
   version node[:mongodb][:package_version]
+  # the 10gen deb package automatically starts mongo, which blocks other
+  # services enabled by this cookbook because of the mongod.lock file.
+  # it should be disabled immediately instead of waiting on the queue
+  # only been tested on ubuntu 12.04 (and also might only be an issue on debian
+  # in general)
+  if platform_family?("debian")
+    notifies :stop, "service[mongodb]", :immediately
+    notifies :disable, "service[mongodb]", :immediately
+  end
 end
 
 


### PR DESCRIPTION
Because the 10gen deb mongo package automatically startups up as a service on install, it messes up the rest of the cookbook. This PR fixes that by immediately stopping and disabling that service (but only for immediate installs, and only on debian).
