### PR TITLE
configserver_url is now configurable on its own, without modifying the FQDN

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,10 @@ default[:mongodb][:auto_configure][:replicaset] = true
 default[:mongodb][:auto_configure][:sharding] = true
 default[:mongodb][:key_file] = nil
 
+# don't use the node's fqdn, but this url instead; something like 'ec2-x-y-z-z.aws.com' or 'cs1.domain.com' (no port)
+# if not provided, will fall back to the FQDN
+default[:mongodb][:configserver_url] = nil
+
 default[:mongodb][:enable_rest] = false
 default[:mongodb][:smallfiles] = false
 

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -80,7 +80,7 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   else
     daemon = "/usr/bin/mongos"
     dbpath = nil
-    configserver = configserver_nodes.collect{|n| "#{n['fqdn']}:#{n['mongodb']['port']}" }.sort.join(",")
+    configserver = configserver_nodes.collect{|n| "#{(n['mongodb']['configserver_url'] || n['fqdn'])}:#{n['mongodb']['port']}" }.sort.join(",")
   end
 
   # default file


### PR DESCRIPTION
Changing the FQDN is a system-wide change, so this PR adds a new attribute `mongodb.configserver_url`, allowing you to set a configserver's public address without changing the FQDN; by default it falls back to `node.fqdn`.
