### PR TITLE
Fix sharding with hidden secondaries.

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -224,7 +224,9 @@ class Chef::ResourceDefinitionList::MongoDB
 
     shard_nodes.each do |n|
       if n['recipes'].include?('mongodb::replicaset')
-
+        # do not include hidden members when calling addShard
+        # see https://jira.mongodb.org/browse/SERVER-9882
+        next if n['mongodb']['replica_hidden']
         key = "rs_#{n['mongodb']['shard_name']}"
       else
         key = '_single'


### PR DESCRIPTION
MongoDB's addShard command fails if the connection string includes hidden members. See https://jira.mongodb.org/browse/SERVER-9882.

Omit hidden members from connection strings to work around this problem.

Without this fix sharding is broken when any of the shards are replica sets with at least one member who has `node[:mongodb][:replica_hidden] == true`.
