### PR TITLE
Fix sysconfig values

### DIFF
--- a/attributes/sysconfig.rb
+++ b/attributes/sysconfig.rb
@@ -1,8 +1,10 @@
 default['mongodb']['sysconfig']['DAEMON'] = "/usr/bin/$NAME"
-default['mongodb']['sysconfig']['DAEMONUSER'] = node['mongodb']['user']
+default['mongodb']['sysconfig']['DAEMON_USER'] = node['mongodb']['user']
 default['mongodb']['sysconfig']['DAEMON_OPTS'] = "--config #{node['mongodb']['configfile']}"
 default['mongodb']['sysconfig']['CONFIGFILE'] = node['mongodb']['configfile']
-# should mongodb start?
 default['mongodb']['sysconfig']['ENABLE_MONGODB'] = "yes"
+
+# these are backward compat purposes
+default['mongodb']['sysconfig']['DAEMONUSER'] = node['mongodb']['sysconfig']['DAEMON_USER']
 default['mongodb']['sysconfig']['ENABLE_MONGOD'] = node['mongodb']['sysconfig']['ENABLE_MONGODB']
 default['mongodb']['sysconfig']['ENABLE_MONGO'] = node['mongodb']['sysconfig']['ENABLE_MONGODB']

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -73,10 +73,10 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
   end
 
   if type != "mongos"
-    daemon = "/usr/bin/mongod"
+    provider = "mongod"
     configserver = nil
   else
-    daemon = "/usr/bin/mongos"
+    provider = "mongos"
     dbpath = nil
     configserver = configserver_nodes.collect{|n| "#{(n['mongodb']['configserver_url'] || n['fqdn'])}:#{n['mongodb']['port']}" }.sort.join(",")
   end
@@ -130,14 +130,15 @@ define :mongodb_instance, :mongodb_type => "mongod" , :action => [:enable, :star
       init_file = File.join(node['mongodb']['init_dir'], "#{name}")
   end
   template init_file do
-    action :create
     cookbook node['mongodb']['template_cookbook']
     source node[:mongodb][:init_script_template]
     group node['mongodb']['root_group']
     owner "root"
     mode "0755"
-    variables :provides => name, :emits_pid => type != "mongos"
-    notifies :restart, "service[#{name}]"
+    variables({
+        :provides => provider
+    })
+    action :create
   end
 
   # service

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -34,7 +34,7 @@ template init_file do
     owner "root"
     mode "0755"
     variables({
-        :provides => 'mongod'
+        :provides => "mongod"
     })
     action :create_if_missing
 end

--- a/templates/default/debian-mongodb.init.erb
+++ b/templates/default/debian-mongodb.init.erb
@@ -98,7 +98,7 @@ DIETIME=10                  # Time to wait for the server to die, in seconds
                             # let some servers to die gracefully and
                             # 'restart' will not work
 
-DAEMONUSER=${DAEMONUSER:-mongodb}
+DAEMON_USER=${DAEMON_USER:-mongodb}
 
 # debugging
 echo "** Running $NAME ($DAEMON $DAEMON_OPTS)"
@@ -137,7 +137,7 @@ running() {
 start_server() {
 # Start the process using the wrapper
             start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
-                        --make-pidfile --chuid $DAEMONUSER \
+                        --make-pidfile --chuid $DAEMON_USER \
                         --exec $NUMACTL $DAEMON $DAEMON_OPTS
             errcode=$?
     return $errcode
@@ -147,7 +147,7 @@ stop_server() {
 # Stop the process using the wrapper
             start-stop-daemon --stop --quiet --pidfile $PIDFILE \
                         --retry 300 \
-                        --user $DAEMONUSER \
+                        --user $DAEMON_USER \
                         --exec $DAEMON
             errcode=$?
     return $errcode

--- a/templates/default/debian-mongodb.init.erb
+++ b/templates/default/debian-mongodb.init.erb
@@ -48,13 +48,13 @@
 #                    functionality are the goals for the project.
 ### END INIT INFO
 #
+NAME=<%= @provides %>
+
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DESC=database
 PIDFILE=/var/run/$NAME.pid
 ENABLE_MONGODB=yes
 SYSCONFIG=<%= node['mongodb']['sysconfig_file'] %>
-
-NAME=<%= @provides %>
 
 # this should get removed at some point for more shell agnostic init script
 ulimit -f <%= node.mongodb.ulimit.fsize %>

--- a/templates/default/debian-mongodb.upstart.erb
+++ b/templates/default/debian-mongodb.upstart.erb
@@ -13,6 +13,7 @@ start on runlevel [2345]
 stop on runlevel [06]
 
 script
+  NAME=<%= @provides %>
   ENABLE_MONGODB="yes"
   if [ -f <%= node['mongodb']['sysconfig_file'] %> ]; then
     . <%= node['mongodb']['sysconfig_file'] %>;


### PR DESCRIPTION
Fixes `DAEMON_USER` and `DAEMONUSER`, use `DAEMON_USER` if possible
Fixes `NAME` not being set properly in init.d and upstart
Fixes `provides` variable being set improperly
