### PR TITLE
fix install of pymongo for mms

### DIFF
--- a/recipes/mms-agent.rb
+++ b/recipes/mms-agent.rb
@@ -14,7 +14,9 @@ chef_gem 'rubyzip'
 # munin-node for hardware info
 package 'munin-node'
 # python dependencies
-python_pip 'pymongo'
+python_pip 'pymongo' do
+  action :install
+end
 
 # download, and unzip if it's changed
 package 'unzip'


### PR DESCRIPTION
The current mms agent recipe doesn't properly install pymongo.  This fixes that.
