### PR TITLE
Update to work on the Amazon Linux AMI

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,7 @@ when "freebsd"
   default[:mongodb][:sysconfig_file] = "/etc/rc.conf.d/mongodb"
   default[:mongodb][:init_dir] = "/usr/local/etc/rc.d"
   default[:mongodb][:root_group] = "wheel"
-when "rhel","fedora"
+when "rhel","fedora","amazon"
   # determine the package name
   # from http://rpm.pbone.net/index.php3?stat=3&limit=1&srodzaj=3&dl=40&search=mongodb
   # verified for RHEL5,6 Fedora 18,19
@@ -77,7 +77,7 @@ when "rhel","fedora"
   default[:mongodb][:default_init_name] = "mongod"
   default[:mongodb][:instance_name] = "mongod"
   # then there is this guy
-  if node['platform'] == 'centos' then
+  if node['platform'] == 'centos' || node['platform'] == 'amazon' then
       Chef::Log.warn("CentOS doesn't provide mongodb, forcing use of 10gen repo")
       default[:mongodb][:install_method] = "10gen"
       default[:mongodb][:package_name] = "mongo-10gen-server"

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -36,7 +36,7 @@ when "debian"
   end
   node.force_override['mongodb']['package_name'] = "mongodb-10gen"
 
-when "rhel","fedora"
+when "rhel","fedora","amazon"
   yum_repository "10gen" do
     description "10gen RPM Repository"
     url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"


### PR DESCRIPTION
The current cookbook was not working for me on the Amazon Linux AMI. It looked like the platform family was omitted. Correcting this in the attribute file as well as downloading the package from 10gen fixed this for me.
