### PR TITLE
Use bind_ip in running() check

### DIFF
--- a/templates/default/debian-mongodb.init.erb
+++ b/templates/default/debian-mongodb.init.erb
@@ -127,7 +127,7 @@ running() {
     pid=`cat $PIDFILE`
     running_pid $pid $DAEMON || return 1
     for i in `seq 1 20`; do
-      nc -z localhost <%= node['mongodb']['port'] %> && return 0
+      nc -z <%= node['mongodb']['bind_ip'] || "localhost" %> <%= node['mongodb']['port'] %> && return 0
       echo -n "."
       sleep 15
     done


### PR DESCRIPTION
Otherwise start/restart successfully acts on the mongod process, but the function will always return 1 after 5 minutes.
