### PR TITLE
fix mms-agent recipe to not clobber the whole installation dir:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 2.0'
-#gem 'chefspec',   '~> 3.0'
+gem 'chefspec',   '~> 3.0'
 #gem 'foodcritic', '~> 3.0'
 #gem 'rubocop',    '~> 0.14'
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For examples see the USAGE section below.
 * `mongodb[:mms_agent][:install_munin]` - If enabled, installs the munin daemon.
 * `mongodb[:mms_agent][:munin_package]` - The name of the munin package to install (if enabled). The default is debian's package name 'munin-node'.
 * `mongodb[:mms_agent][:enable_munin]` - Enable MMS Agent integration with munin.
+* `mongodb[:mms_agent][:ignore_failure_on_install]` - Don't abort the chef run if there was a problem during install, e.g. downloading the archive
 
 # USAGE:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ For examples see the USAGE section below.
 * `mongodb[:mms_agent][:install_munin]` - If enabled, installs the munin daemon.
 * `mongodb[:mms_agent][:munin_package]` - The name of the munin package to install (if enabled). The default is debian's package name 'munin-node'.
 * `mongodb[:mms_agent][:enable_munin]` - Enable MMS Agent integration with munin.
-* `mongodb[:mms_agent][:ignore_failure_on_install]` - Don't abort the chef run if there was a problem during install, e.g. downloading the archive
 
 # USAGE:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ For examples see the USAGE section below.
 * `mongodb[:mms_agent][:secret_key]` - MMS Agent API Key
 * `mongodb[:mms_agent][:install_dir]` - Location to install the agent
 * `mongodb[:mms_agent][:log_dir]` - Location to write the agent logfile. If this is a relative path, it's relative to where the service is run (via runit), e.g. set to './main'
+* `mongodb[:mms_agent][:install_munin]` - If enabled, installs the munin daemon.
+* `mongodb[:mms_agent][:munin_package]` - The name of the munin package to install (if enabled). The default is debian's package name 'munin-node'.
+* `mongodb[:mms_agent][:enable_munin]` - Enable MMS Agent integration with munin.
 
 # USAGE:
 

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,5 +1,13 @@
 default[:mongodb][:mms_agent][:api_key] = ""
 default[:mongodb][:mms_agent][:secret_key] = ""
 
-default[:mongodb][:mms_agent][:install_dir] = "/usr/local/share"
+# shouldn't need to changed, but configurable anyways
+default[:mongodb][:mms_agent][:install_url] = "https://mms.mongodb.com/settings/mms-monitoring-agent.zip"
+# N.B. the dir MUST be named mms-agent; this is the contents of the unarchived zip
+# the location of the dir (i.e. /usr/local/share) can be freely changed
+default[:mongodb][:mms_agent][:install_dir] = "/usr/local/share/mms-agent"
 default[:mongodb][:mms_agent][:log_dir] = "#{node[:mongodb][:logpath]}/agent"
+default[:mongodb][:mms_agent][:install_munin] = true
+# this is the debian package name
+default[:mongodb][:mms_agent][:munin_package] = 'munin-node'
+default[:mongodb][:mms_agent][:enable_munin] = true

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -11,3 +11,6 @@ default[:mongodb][:mms_agent][:install_munin] = true
 # this is the debian package name
 default[:mongodb][:mms_agent][:munin_package] = 'munin-node'
 default[:mongodb][:mms_agent][:enable_munin] = true
+
+# don't abort the chef run if there was a problem during install, e.g. downloading the archive
+default[:mongodb][:mms_agent][:ignore_failure_on_install] = true

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -6,7 +6,7 @@ default[:mongodb][:mms_agent][:install_url] = "https://mms.mongodb.com/settings/
 # N.B. the dir MUST be named mms-agent; this is the contents of the unarchived zip
 # the location of the dir (i.e. /usr/local/share) can be freely changed
 default[:mongodb][:mms_agent][:install_dir] = "/usr/local/share/mms-agent"
-default[:mongodb][:mms_agent][:log_dir] = "#{node[:mongodb][:logpath]}/agent"
+default[:mongodb][:mms_agent][:log_dir] = "#{node[:mongodb][:config][:logpath]}/agent"
 default[:mongodb][:mms_agent][:install_munin] = true
 # this is the debian package name
 default[:mongodb][:mms_agent][:munin_package] = 'munin-node'

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -11,6 +11,3 @@ default[:mongodb][:mms_agent][:install_munin] = true
 # this is the debian package name
 default[:mongodb][:mms_agent][:munin_package] = 'munin-node'
 default[:mongodb][:mms_agent][:enable_munin] = true
-
-# don't abort the chef run if there was a problem during install, e.g. downloading the archive
-default[:mongodb][:mms_agent][:ignore_failure_on_install] = true

--- a/recipes/mms-agent.rb
+++ b/recipes/mms-agent.rb
@@ -26,13 +26,12 @@ remote_file "#{Chef::Config[:file_cache_path]}/mms-monitoring-agent.zip" do
   # irrelevant because of https://jira.mongodb.org/browse/MMSSUPPORT-2258
   checksum node.mongodb.mms_agent.checksum if node.mongodb.mms_agent.key?(:checksum)
   notifies :run, "bash[unzip mms-monitoring-agent]", :immediately
-  ignore_failure node.mongodb.mms_agent.ignore_failure_on_install
 end
-directory File.dirname(node.mongodb.mms_agent.install_dir) do
+directory "#{node.mongodb.mms_agent.install_dir}/.." do
   recursive true
 end
 bash 'unzip mms-monitoring-agent' do
-  code "rm -rf #{node.mongodb.mms_agent.install_dir} && unzip -o -d #{File.dirname(node.mongodb.mms_agent.install_dir)} #{Chef::Config[:file_cache_path]}/mms-monitoring-agent.zip"
+  code "rm -rf #{node.mongodb.mms_agent.install_dir} && unzip -o -d #{Pathname.new(node.mongodb.mms_agent.install_dir).parent} #{Chef::Config[:file_cache_path]}/mms-monitoring-agent.zip"
   action :nothing
   only_if {
     def checksum_zip_contents(zipfile)
@@ -52,7 +51,6 @@ bash 'unzip mms-monitoring-agent' do
     node.default.mongodb.mms_agent.checksum = new_checksum
     should_install
   }
-  ignore_failure node.mongodb.mms_agent.ignore_failure_on_install
 end
 
 # runit and agent logging
@@ -69,7 +67,6 @@ mms_agent_service = runit_service 'mms-agent' do
     :mms_agent_log_dir => node.mongodb.mms_agent.log_dir
   })
   action :nothing
-  ignore_failure node.mongodb.mms_agent.ignore_failure_on_install
 end
 
 # update settings.py and restart the agent if there were any key changes
@@ -100,6 +97,4 @@ ruby_block 'modify settings.py' do
       notifies :restart, mms_agent_service, :delayed
     end
   end
-  only_if { File.exists?("#{node.mongodb.mms_agent.install_dir}/settings.py") }
-  ignore_failure node.mongodb.mms_agent.ignore_failure_on_install
 end

--- a/spec/unit/recipes/mms-agent_spec.rb
+++ b/spec/unit/recipes/mms-agent_spec.rb
@@ -20,14 +20,16 @@ describe 'mongodb::mms-agent' do
     expect(chef_run).not_to install_package(chef_run.node.mongodb.mms_agent.munin_package)
   end
 
-  it 'does not clobber anything else' do
-    # add some files to install_dir
-    expected_file = "#{chef_run.node.mongodb.mms_agent.install_dir}/f.txt"
-    expected_string = "hello mongodb"
-    File.open(expected_file, 'w') { |f| f.write(expected_string) }
+  describe 'chefspec actually issues real commands on the local client, disabled for now' do
+    xit 'does not clobber anything else' do
+      # add some files to install_dir
+      expected_file = "#{chef_run.node.mongodb.mms_agent.install_dir}/f.txt"
+      expected_string = "hello mongodb"
+      File.open(expected_file, 'w') { |f| f.write(expected_string) }
 
-    # converge and check the file and string are still there
-    chef_run.converge(described_recipe)
-    File.open(expected_file, 'r') { |f| expect(f.read).to eq(expected_string) }
+      # converge and check the file and string are still there
+      chef_run.converge(described_recipe)
+      File.open(expected_file, 'r') { |f| expect(f.read).to eq(expected_string) }
+    end
   end
 end

--- a/spec/unit/recipes/mms-agent_spec.rb
+++ b/spec/unit/recipes/mms-agent_spec.rb
@@ -1,0 +1,33 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+describe 'mongodb::mms-agent' do
+  let(:chef_run) {
+    stub_command("/usr/bin/python -c 'import setuptools'").and_return(true)
+    ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04') do |n|
+      n.set.mongodb.mms_agent.install_dir = '/usr/local/share'
+    end
+  }
+
+  it 'installs munin by default' do
+    chef_run.converge(described_recipe)
+    expect(chef_run).to install_package(chef_run.node.mongodb.mms_agent.munin_package)
+  end
+
+  it 'does not install munin if you say so' do
+    chef_run.node.set.mongodb.mms_agent.install_munin = false
+    chef_run.converge(described_recipe)
+    expect(chef_run).not_to install_package(chef_run.node.mongodb.mms_agent.munin_package)
+  end
+
+  it 'does not clobber anything else' do
+    # add some files to install_dir
+    expected_file = "#{chef_run.node.mongodb.mms_agent.install_dir}/f.txt"
+    expected_string = "hello mongodb"
+    File.open(expected_file, 'w') { |f| f.write(expected_string) }
+
+    # converge and check the file and string are still there
+    chef_run.converge(described_recipe)
+    File.open(expected_file, 'r') { |f| expect(f.read).to eq(expected_string) }
+  end
+end

--- a/templates/default/sv-mms-agent-run.erb
+++ b/templates/default/sv-mms-agent-run.erb
@@ -3,4 +3,4 @@
 cd <%= @options[:mms_agent_install_dir] %>
 
 exec 2>&1
-exec chpst -u root:root python <%= @options[:mms_agent_install_dir] %>/mms-agent/agent.py 2>&1
+exec chpst -u root:root python <%= @options[:mms_agent_install_dir] %>/agent.py 2>&1


### PR DESCRIPTION
The existing installation process blows away its installation dir, which is not
polite if it's /usr/local/share (which is the default); plenty of other
software installs stuff there.

Changes:
- mms_agent.install_dir now correctly points to the actual install dir, and not
  its parent
- use chef's file cache instead of /tmp
- improved handling of installation dir
- both the installation and use of munin is now configurable via attribute
