### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ This cookbook depends on these external cookbooks
 
 ## Platform:
 
-The cookbook aims to be platform independant, but is best tested on debian squeeze systems.
+The cookbook aims to be platform independent, but is best tested on debian squeeze systems.
 
 The `10gen_repo` recipe configures the package manager to use 10gen's
-official package reposotories on Debian, Ubuntu, Redhat, CentOS, Fedora, and
+official package repositories on Debian, Ubuntu, Redhat, CentOS, Fedora, and
 Amazon linux distributions.
 
 # DEFINITIONS:
@@ -41,7 +41,7 @@ For examples see the USAGE section below.
 * `mongodb[:dbpath]` - Location for mongodb data directory, defaults to "/var/lib/mongodb"
 * `mongodb[:logpath]` - Path for the logfiles, default is "/var/log/mongodb"
 * `mongodb[:port]` - Port the mongod listens on, default is 27017
-* `mongodb[:client_role]` - Role identifing all external clients which should have access to a mongod instance
+* `mongodb[:client_role]` - Role identifying all external clients which should have access to a mongod instance
 * `mongodb[:cluster_name]` - Name of the cluster, all members of the cluster must
     reference to the same name, as this name is used internally to identify all
     members of a cluster.

--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -5,7 +5,7 @@
 
 default['mongodb']['config']['port'] = node['mongodb']['port'] || 27017
 default['mongodb']['config']['bind_ip'] = node['mongodb']['bind_ip'] || "0.0.0.0"
-default['mongodb']['config']['logpath'] = File.join(node['mongodb']['logpath'], "mongodb.log")
+default['mongodb']['config']['logpath'] = File.join(node['mongodb']['logpath'] || "/var/log/mongodb", "mongodb.log")
 default['mongodb']['config']['logappend'] = true
 if node.platform_family?("rhel", "fedora") then
     default['mongodb']['config']['fork'] = true

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -34,7 +34,7 @@ when "debian"
     key "7F0CEB10"
     action :add
   end
-  node.force_override['mongodb']['package_name'] = "mongodb-10gen"
+  node.override['mongodb']['package_name'] = "mongodb-10gen"
 
 when "rhel","fedora","amazon"
   yum_repository "10gen" do
@@ -42,7 +42,7 @@ when "rhel","fedora","amazon"
     url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
     action :add
   end
-  node.force_override['mongodb']['package_name'] = "mongo-10gen-server"
+  node.override['mongodb']['package_name'] = "mongo-10gen-server"
 
 else
     # pssst build from source


### PR DESCRIPTION
- README.md misspellings
- Default the logpath in case it isn't set
- Relax package name override so cookbook can work on Chef 10
