### PR TITLE
Download MMS agent from new location

### DIFF
--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,5 +1,6 @@
 default[:mongodb][:mms_agent][:api_key] = ""
 default[:mongodb][:mms_agent][:secret_key] = ""
 
+default[:mongodb][:mms_agent][:source_uri] = "https://mms.mongodb.com/settings/mms-monitoring-agent.zip"
 default[:mongodb][:mms_agent][:install_dir] = "/usr/local/share"
 default[:mongodb][:mms_agent][:log_dir] = "#{node[:mongodb][:logpath]}/agent"

--- a/recipes/mms-agent.rb
+++ b/recipes/mms-agent.rb
@@ -19,7 +19,7 @@ python_pip 'pymongo'
 # download, and unzip if it's changed
 package 'unzip'
 remote_file '/tmp/10gen-mms-agent.zip' do
-  source 'https://mms.10gen.com/settings/10gen-mms-agent.zip'
+  source node['mongodb']['mms_agent']['source_uri']
   # irrelevant because of https://jira.mongodb.org/browse/MMSSUPPORT-2258
   checksum node.mongodb.mms_agent.checksum if node.mongodb.mms_agent.key?(:checksum)
   notifies :run, "bash[unzip 10gen-mms-agent]", :immediately


### PR DESCRIPTION
MMS's documentation says this is the new URI for fetching the agent in automation tools.  The old location currently contains a 302 but unsure how long that will be there.
