### PR TITLE
Add "mongodb::default" attributes file dependency

### DIFF
--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -3,6 +3,8 @@
 # dump anything into default['mongodb']['config'][<setting>] = <value>
 # these options are in the order of mongodb docs
 
+include_attribute "mongodb::default"
+
 default['mongodb']['config']['port'] = node['mongodb']['port'] || 27017
 default['mongodb']['config']['bind_ip'] = node['mongodb']['bind_ip'] || "0.0.0.0"
 default['mongodb']['config']['logpath'] = File.join(node['mongodb']['logpath'] || "/var/log/mongodb", "mongodb.log")

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,3 +1,5 @@
+include_attribute "mongodb::default"
+
 default[:mongodb][:mms_agent][:api_key] = ""
 default[:mongodb][:mms_agent][:secret_key] = ""
 

--- a/attributes/sysconfig.rb
+++ b/attributes/sysconfig.rb
@@ -1,3 +1,5 @@
+include_attribute "mongodb::default"
+
 default['mongodb']['sysconfig']['DAEMON'] = "/usr/bin/$NAME"
 default['mongodb']['sysconfig']['DAEMON_USER'] = node['mongodb']['user']
 default['mongodb']['sysconfig']['DAEMON_OPTS'] = "--config #{node['mongodb']['configfile']}"


### PR DESCRIPTION
Some attributes files use attributes that might have not been assigned by the
user. Therefore, they need default values initialized.
