### PR TITLE
use the default service name for shard and config server

### DIFF
--- a/recipes/configserver.rb
+++ b/recipes/configserver.rb
@@ -23,15 +23,10 @@ node.set[:mongodb][:is_configserver] = true
 
 include_recipe "mongodb::install"
 
-service "mongodb" do
-  supports :status => true, :restart => true
-  action [:disable, :stop]
-end
-
 # we are not starting the configserver service with the --configsvr
 # commandline option because right now this only changes the port it's
 # running on, and we are overwriting this port anyway.
-mongodb_instance "configserver" do
+mongodb_instance node['mongodb']['instance_name'] do
   mongodb_type "configserver"
   port         node['mongodb']['port']
   logpath      node['mongodb']['logpath']

--- a/recipes/shard.rb
+++ b/recipes/shard.rb
@@ -23,16 +23,10 @@ node.set[:mongodb][:is_shard] = true
 
 include_recipe "mongodb::install"
 
-# disable and stop the default mongodb instance
-service "mongodb" do
-  supports :status => true, :restart => true
-  action [:disable, :stop]
-end
-
 # we are not starting the shard service with the --shardsvr
 # commandline option because right now this only changes the port it's
 # running on, and we are overwriting this port anyway.
-mongodb_instance "shard" do
+mongodb_instance node['mongodb']['instance_name'] do
   mongodb_type "shard"
   port         node['mongodb']['port']
   logpath      node['mongodb']['logpath']


### PR DESCRIPTION
configure node[:mongodb][:instance_name] if you want something else

I asked about why a separate `shard` service was configured in https://github.com/edelight/chef-mongodb/issues/174#issuecomment-30366322 and didn't here back.

With the exception of mongos, it seems like the most common use case would be to simply run a configured mongodb service. Also, on Ubuntu there is some strangeness in how services are disabled for upstart: https://tickets.opscode.com/browse/CHEF-3624 

I suppose one might want to configure multiple services on a single node for multiple mongod instances. I am not entirely how that would work with attribute configuration though. More fodder for documentation....
