### PR TITLE
Fix token replacement in mms-agent recipe and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ For examples see the USAGE section below.
 * `mongodb[:replica_votes]` - Number of [votes](http://docs.mongodb.org/manual/reference/replica-configuration/#local.system.replset.members[n].votes) node will cast in an election.
 * `mongodb[:package_version]` - Version of the MongoDB package to install, default is nil
 * `mongodb[:mms_agent][:api_key]` - MMS Agent API Key
-* `mongodb[:mms_agent][:secret_key]` - MMS Agent API Key
+* `mongodb[:mms_agent][:mms_server]` - MMS Server (default: `https://mms.mongodb.com`)
+* `mongodb[:mms_agent][:require_valid_server_cert]` - Require valid server certificate (default: `false`)
 * `mongodb[:mms_agent][:install_dir]` - Location to install the agent
 * `mongodb[:mms_agent][:log_dir]` - Location to write the agent logfile. If this is a relative path, it's relative to where the service is run (via runit), e.g. set to './main'
 * `mongodb[:mms_agent][:install_munin]` - If enabled, installs the munin daemon.
@@ -179,8 +180,7 @@ production MongoDB deployments.
 
 
 To setup MMS, simply set your keys in
-`node['mongodb']['mms_agent']['api_key']` and
-`node['mongodb']['mms_agent']['secret_key']`, then add the
+`node['mongodb']['mms_agent']['api_key']` and then add the
 `mongodb::mms-agent` recipe to your run list. Your current keys should
 be available at your {MMS Settings page}[https://mms.10gen.com/settings].
 

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,5 +1,6 @@
 include_attribute "mongodb::default"
 
+default[:mongodb][:mms_agent][:mms_server] = "https://mms.mongodb.com"
 default[:mongodb][:mms_agent][:api_key] = ""
 
 # shouldn't need to changed, but configurable anyways

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,7 +1,6 @@
 include_attribute "mongodb::default"
 
 default[:mongodb][:mms_agent][:api_key] = ""
-default[:mongodb][:mms_agent][:secret_key] = ""
 
 # shouldn't need to changed, but configurable anyways
 default[:mongodb][:mms_agent][:install_url] = "https://mms.mongodb.com/settings/mms-monitoring-agent.zip"
@@ -13,3 +12,5 @@ default[:mongodb][:mms_agent][:install_munin] = true
 # this is the debian package name
 default[:mongodb][:mms_agent][:munin_package] = 'munin-node'
 default[:mongodb][:mms_agent][:enable_munin] = true
+
+default[:mongodb][:mms_agent][:require_valid_server_cert] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -100,8 +100,11 @@ attribute "mongodb/mms_agent",
 attribute "mongodb/mms_agent/api_key",
   :display_name => "MMS Agent API Key"
 
-attribute "mongodb/mms_agent/secret_key",
-  :display_name => "MMS Agent Secret Key"
+attribute "mongodb/mms_agent/mm_server",
+  :display_name => "MMS Server"
+
+attribute "mongodb/mms_agent/require_valid_server_cert",
+  :display_name => "Require valid certificate from server"
 
 attribute "mongodb/oplog_size",
   :display_name => "oplogSize",

--- a/recipes/mms-agent.rb
+++ b/recipes/mms-agent.rb
@@ -72,7 +72,7 @@ end
 # update settings.py and restart the agent if there were any key changes
 ruby_block 'modify settings.py' do
   block do
-    Chef::Log.warn "Found empty mms_agent.api_key or mms_agent.secret_key attributes" if node.mongodb.mms_agent.api_key.empty? || node.mongodb.mms_agent.secret_key.empty?
+    Chef::Log.warn "Found empty mms_agent.api_key attribute" if node.mongodb.mms_agent.api_key.empty?
 
     orig_s = ''
     open("#{node.mongodb.mms_agent.install_dir}/settings.py") { |f|

--- a/recipes/mms-agent.rb
+++ b/recipes/mms-agent.rb
@@ -79,10 +79,12 @@ ruby_block 'modify settings.py' do
       orig_s = f.read
     }
     s = orig_s
-    s = s.gsub(/mms_key = ".*"/, "mms_key = \"#{node.mongodb.mms_agent.api_key}\"")
-    s = s.gsub(/secret_key = ".*"/, "secret_key = \"#{node.mongodb.mms_agent.secret_key}\"")
+    s = s.gsub(/@MMS_SERVER@/, "#{node.mongodb.mms_agent.api_key}")
+    s = s.gsub(/@API_KEY@/, "#{node.mongodb.mms_agent.api_key}")
     # python uses True/False not true/false
     s = s.gsub(/enableMunin = .*/, "enableMunin = #{node.mongodb.mms_agent.enable_munin ? "True" : "False"}")
+    s = s.gsub(/@DEFAULT_REQUIRE_VALID_SERVER_CERTIFICATES@/, "#{node.mongodb.mms_agent.require_valid_server_cert ? "True" : "False"}")
+    
     if s != orig_s
       Chef::Log.debug "Settings changed, overwriting and restarting service"
       open("#{node.mongodb.mms_agent.install_dir}/settings.py", 'w') { |f|

--- a/recipes/mms-agent.rb
+++ b/recipes/mms-agent.rb
@@ -79,7 +79,7 @@ ruby_block 'modify settings.py' do
       orig_s = f.read
     }
     s = orig_s
-    s = s.gsub(/@MMS_SERVER@/, "#{node.mongodb.mms_agent.api_key}")
+    s = s.gsub(/@MMS_SERVER@/, "#{node.mongodb.mms_agent.mms_server}")
     s = s.gsub(/@API_KEY@/, "#{node.mongodb.mms_agent.api_key}")
     # python uses True/False not true/false
     s = s.gsub(/enableMunin = .*/, "enableMunin = #{node.mongodb.mms_agent.enable_munin ? "True" : "False"}")


### PR DESCRIPTION
I noticed that the token replacement that was being done in the settings.py was broken. 
The tokens that need to be replaced were `@API_KEY@`, `@MMS_SERVER` and `@ DEFAULT_REQUIRE_VALID_SERVER_CERTIFICATES@`.

Without these the mms-agent fails to initialize.
