### PR TITLE
install bson_ext with mongo gem to suppress warning

### DIFF
--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -1,11 +1,15 @@
-# install the mongo ruby gem at compile time to make it globally available
-if(Gem.const_defined?("Version") and Gem::Version.new(Chef::VERSION) < Gem::Version.new('10.12.0'))
-  gem_package 'mongo' do
-    action :nothing
-  end.run_action(:install)
-  Gem.clear_paths
-else
-  chef_gem 'mongo' do
-    action :install
+# install the mongo and bson_ext ruby gems at compile time to make them globally available
+gems = 'mongo', 'bson_ext'
+
+gems.each do |g|
+  if Gem.const_defined?("Version") and Gem::Version.new(Chef::VERSION) < Gem::Version.new('10.12.0')
+    gem_package g do
+      action :nothing
+    end.run_action(:install)
+    Gem.clear_paths
+  else
+    chef_gem g do
+      action :install
+    end
   end
 end

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -1,4 +1,5 @@
 # install the mongo and bson_ext ruby gems at compile time to make them globally available
+# TODO: remove bson_ext once mongo gem supports bson >= 2
 gems = 'mongo', 'bson_ext'
 
 gems.each do |g|


### PR DESCRIPTION
This will no longer appear when configuring the replicaset or shard:

```
[2014-01-28T14:36:43+00:00] INFO: service[mongodb] sending create action to ruby_block[config_replicaset] (delayed)
[2014-01-28T14:36:43+00:00] INFO: Processing ruby_block[config_replicaset] action create (mongodb::shard line 210)
      ** Notice: The native BSON extension was not loaded. **

      For optimal performance, use of the BSON extension is recommended.

      To enable the extension make sure ENV['BSON_EXT_DISABLED'] is not set
      and run the following command:

        gem install bson_ext

      If you continue to receive this message after installing, make sure that
      the bson_ext gem is in your load path.

[2014-01-28T14:36:43+00:00] INFO: Configuring replicaset with members shard1-mongodb01
[2014-01-28T14:36:43+00:00] INFO: ruby_block[config_replicaset] called
```
