### PR TITLE
Update install.rb

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -52,7 +52,7 @@ template init_file do
     :bind_ip =>        node['mongodb']['config']['bind_ip'],
     :port =>           node['mongodb']['config']['port']
   )
-  action :create_if_missing
+  action :create
 end
 
 packager_opts = ''


### PR DESCRIPTION
changed the action of the init script from :create_if_missing to :create

the reason for this change is is anything should change in the parameters passed to the init script
(bind_ip, port etc) these changes will not be reflected in the script on the machine.
