### PR TITLE
pull request for issue 234

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -99,7 +99,7 @@ class Chef::ResourceDefinitionList::MongoDB
     if result.fetch('ok', nil) == 1
       # everything is fine, do nothing
     elsif result.fetch('errmsg', nil) =~ /(\S+) is already initiated/ || (result.fetch('errmsg', nil) == 'already initialized')
-      server, port = Regexp.last_match[1].nil? ? ['localhost', node['mongodb']['config']['port']] : Regexp.last_match[1].split(':')
+      server, port = Regexp.last_match.nil? || Regexp.last_match.length < 2 ? ['localhost', node['mongodb']['port']] : Regexp.last_match[1].split(':')
       begin
         connection = Mongo::Connection.new(server, port, :op_timeout => 5, :slave_ok => true)
       rescue


### PR DESCRIPTION
As I mentioned in the issue, I'm not sure why last_match is expected to have anything.  I don't see where it could have been previously used.

I just added to the conditional to check for nil and that the length is at least 2 since last_match[1] is referenced.  Perhaps the last_match portion could be removed completely but I wanted to err on the side of caution.

This got it working for me.  Without this, chef-client runs after the initial one would fail.
