### PR TITLE
recipe[10gen_repo]: update for yum cookbook >= 3.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ recipe 'mongodb::mms-agent', 'Installs and configures a Mongo Management Service
 depends 'apt', '>= 1.8.2'
 depends 'python', '>= 1.3.0'
 depends 'runit', '>= 1.1.6'
-depends 'yum'
+depends 'yum', '>= 3.0.0'
 
 %w{ ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|
   supports os

--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -38,8 +38,9 @@ when 'debian'
 when 'rhel', 'fedora'
   yum_repository '10gen' do
     description '10gen RPM Repository'
-    url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
-    action :add
+    baseurl "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
+    action :create
+    gpgcheck false
   end
   node.override['mongodb']['package_name'] = 'mongo-10gen-server'
 


### PR DESCRIPTION
The `yum` cookbook introduced some non-backwards compatible changes in version `3.0.0`, one of them being a change in the attributes for the `yum_repository` LWRP. Namely, `url` is now `baseurl`, `action` should be `:create` instead of `:add` and `gpgcheck false` needs to be specified explicitly.

This commit introduces a dependency on `yum >= 3.0.0` and fixes the `10gen_repo` recipe to work with the new version.
