### PR TITLE
Update configserver.rb

### DIFF
--- a/recipes/configserver.rb
+++ b/recipes/configserver.rb
@@ -20,6 +20,7 @@
 #
 
 node.set[:mongodb][:is_configserver] = true
+node.set[:mongodb][:cluster_name]=  node['mongodb']['cluster_name']
 
 include_recipe 'mongodb::install'
 


### PR DESCRIPTION
The config server is not populating the node value for cluster_name and when this variable is being searched chef does not find the servers. This solves bug #247
