### PR TITLE
Update install.rb

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,5 +1,10 @@
 include_recipe 'mongodb::10gen_repo' if node['mongodb']['install_method'] == '10gen' || node.run_list.recipes.include?('mongodb::10gen_repo')
 
+if node.mongodb.is_replicaset || node.mongodb.is_shard
+    node.set[:mongodb][:cluster_name]=  node['mongodb']['cluster_name']
+    node.set[:mongodb][:shard_name]=  node['mongodb']['shard_name']
+end
+
 # prevent-install defaults, but don't overwrite
 file node['mongodb']['sysconfig_file'] do
   content 'ENABLE_MONGODB=no'


### PR DESCRIPTION
in response to the discussion relating to #243 this PR modifies the install.rb allowing for the setting of the normal attributes which appear to index immediately allowing for smoother deployment of multiple replicaset and or shard nodes.

the original PR put these lines in the replicaset recipe which meant this wasn't taken into consideration on shard nodes that were not part of a replicaset.

putting these same lines here in install works for both cases as the is_replicaset and is_shard attributes are set prior to including the install recipe in each of the replicaset and shard recipes
