### PR TITLE
Update mongodb.rb

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -217,7 +217,7 @@ class Chef::ResourceDefinitionList::MongoDB
         # do not include hidden members when calling addShard
         # see https://jira.mongodb.org/browse/SERVER-9882
         next if n['mongodb']['replica_hidden']
-        key = "rs_#{n['mongodb']['shard_name']}"
+        key = "#{n['mongodb']['replicaset_name']}"
       else
         key = '_single'
       end


### PR DESCRIPTION
when adding a replicaset as a shard you have to use the replicaset name as the prefix

this recipe was computing a name based on rs_#{n['mongodb']['shard_name']} which results in mongos not wanting to add the shard with the following error:

mongo addshard couldn't connect to new shard socket exception

at first I thought there to be an issue with hosts/ips but after trying the commands manually and verifying ipaddresses and services running the only way to make mongo add the shards was to change the prefix to the replicaset_name
