### PR TITLE
Use new MMS monitoring and backup agent packages

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -107,6 +107,8 @@ suites:
         api_key: "random key"
         monitoring:
           sslRequireValidServerCertificates: false
+  excludes:
+    - ubuntu-10.04
 
 - name: mms_backup_agent
   run_list:
@@ -117,3 +119,5 @@ suites:
         api_key: "random key"
         backup:
           sslRequireValidServerCertificates: false
+  excludes:
+    - ubuntu-10.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -109,7 +109,8 @@ suites:
           sslRequireValidServerCertificates: false
   excludes:
     - ubuntu-10.04
-
+    - debian-7.2.0
+    
 - name: mms_backup_agent
   run_list:
   - "recipe[mongodb::mms_backup_agent]"
@@ -121,3 +122,4 @@ suites:
           sslRequireValidServerCertificates: false
   excludes:
     - ubuntu-10.04
+    - debian-7.2.0

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,7 @@ platforms:
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
   run_list:
   - "recipe[yum]"
+  - "recipe[yum-epel]"
 
 - name: centos-5.10
   driver_config:
@@ -40,6 +41,7 @@ platforms:
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.10_chef-provisionerless.box
   run_list:
   - "recipe[yum]"
+  - "recipe[yum-epel]"
 
 # not going to try until
 # https://jira.mongodb.org/browse/SERVER-7285 is closed
@@ -97,6 +99,9 @@ suites:
     mongodb:
       mms_agent:
         api_key: "random key"
+  excludes:
+    # runit is failing to install
+    - centos-5.10
 
 - name: mms_monitoring_agent
   run_list:
@@ -108,8 +113,11 @@ suites:
         monitoring:
           sslRequireValidServerCertificates: false
   excludes:
+    # Upstart script uses setuid which is not present in this version
     - ubuntu-10.04
+    # Upstart is not present
     - debian-7.2.0
+    # Package does not create the user
     - centos-5.10
     
 - name: mms_backup_agent
@@ -122,6 +130,9 @@ suites:
         backup:
           sslRequireValidServerCertificates: false
   excludes:
+    # Upstart script uses setuid which is not present in this version
     - ubuntu-10.04
+    # Upstart is not present
     - debian-7.2.0
+    # Package does not create the user
     - centos-5.10

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -92,8 +92,28 @@ suites:
 
 - name: mms_agent
   run_list:
-  - "recipe[mongodb::mms-agent]"
+  - "recipe[mongodb::mms_agent]"
   attributes:
     mongodb:
       mms_agent:
         api_key: "random key"
+
+- name: mms_monitoring_agent
+  run_list:
+  - "recipe[mongodb::mms_monitoring_agent]"
+  attributes:
+    mongodb:
+      mms_agent:
+        api_key: "random key"
+        monitoring:
+          sslRequireValidServerCertificates: false
+
+- name: mms_backup_agent
+  run_list:
+  - "recipe[mongodb::mms_backup_agent]"
+  attributes:
+    mongodb:
+      mms_agent:
+        api_key: "random key"
+        backup:
+          sslRequireValidServerCertificates: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -110,6 +110,7 @@ suites:
   excludes:
     - ubuntu-10.04
     - debian-7.2.0
+    - centos-5.10
     
 - name: mms_backup_agent
   run_list:
@@ -123,3 +124,4 @@ suites:
   excludes:
     - ubuntu-10.04
     - debian-7.2.0
+    - centos-5.10

--- a/README.md
+++ b/README.md
@@ -76,14 +76,11 @@ Basically all settings defined in the Configuration File Options documentation p
 
 
 ## MMS Agent attributes
-* `mongodb[:mms_agent][:api_key]` - MMS Agent API Key
-* `mongodb[:mms_agent][:mms_server]` - MMS Server (default: `https://mms.mongodb.com`)
-* `mongodb[:mms_agent][:require_valid_server_cert]` - Require valid server certificate (default: `false`)
-* `mongodb[:mms_agent][:install_dir]` - Location to install the agent
-* `mongodb[:mms_agent][:log_dir]` - Location to write the agent logfile. If this is a relative path, it's relative to where the service is run (via runit), e.g. set to './main'
-* `mongodb[:mms_agent][:install_munin]` - If enabled, installs the munin daemon.
-* `mongodb[:mms_agent][:munin_package]` - The name of the munin package to install (if enabled). The default is debian's package name 'munin-node'.
-* `mongodb[:mms_agent][:enable_munin]` - Enable MMS Agent integration with munin.
+* `mongodb[:mms_agent][:api_key]` - MMS Agent API Key. Required.
+* `mongodb[:mms_agent][:monitoring][:version]` - Version of the MongoDB MMS Monitoring Agent package to download and install. Required.
+* `mongodb[:mms_agent][:monitoring][:<setting>]` - General MongoDB MMS Monitoring Agent configuration file option.  
+* `mongodb[:mms_agent][:backup][:version]` - Version of the MongoDB MMS Backup Agent package to download and install. Required. 
+* `mongodb[:mms_agent][:backup][:<setting>]` - General MongoDB MMS Monitoring Agent configuration file option.  
 
 # USAGE:
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,47 @@ Basically all settings defined in the Configuration File Options documentation p
 
 
 ## MMS Agent attributes
-* `mongodb[:mms_agent][:api_key]` - MMS Agent API Key. Required.
-* `mongodb[:mms_agent][:monitoring][:version]` - Version of the MongoDB MMS Monitoring Agent package to download and install. Required.
+
+* `mongodb[:mms_agent][:api_key]` - MMS Agent API Key. No default, required.
+* `mongodb[:mms_agent][:monitoring][:version]` - Version of the MongoDB MMS Monitoring Agent package to download and install. Default is '2.0.0.17-1', required.
 * `mongodb[:mms_agent][:monitoring][:<setting>]` - General MongoDB MMS Monitoring Agent configuration file option.  
-* `mongodb[:mms_agent][:backup][:version]` - Version of the MongoDB MMS Backup Agent package to download and install. Required. 
+* `mongodb[:mms_agent][:backup][:version]` - Version of the MongoDB MMS Backup Agent package to download and install. Default is '1.4.3.28-1', required.
 * `mongodb[:mms_agent][:backup][:<setting>]` - General MongoDB MMS Monitoring Agent configuration file option.  
+
+### Monitoring Agent Settings
+
+The defaults values installed by the package are:
+
+```
+mmsBaseUrl=https://mms.mongodb.com
+globalAuthUsername=
+globalAuthPassword=
+configCollectionsEnabled=true
+configDatabasesEnabled=true
+throttlePassesShardChunkCounts = 10
+throttlePassesDbstats = 20
+throttlePassesOplog = 10
+disableProfileDataCollection=false
+disableGetLogsDataCollection=false
+disableLocksAndRecordStatsDataCollection=false
+enableMunin=true
+useSslForAllConnections=false
+sslTrustedServerCertificates=
+sslRequireValidServerCertificates=false
+krb5Principal=
+krb5Keytab=
+```
+
+### Backup Agent Settings
+
+The defaults values installed by the package are:
+
+```
+mothership=api-backup.mongodb.com
+https=true
+sslTrustedServerCertificates=
+sslRequireValidServerCertificates=false
+```
 
 # USAGE:
 

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,18 +1,3 @@
-include_attribute 'mongodb::default'
-include_attribute 'mongodb::dbconfig'
+default[:mongodb][:mms_agent][:monitoring][:version] = '2.0.0.17-1'
+default[:mongodb][:mms_agent][:backup][:version] = '1.4.3.28-1'
 
-default[:mongodb][:mms_agent][:mms_server] = 'https://mms.mongodb.com'
-default[:mongodb][:mms_agent][:api_key] = ''
-
-# shouldn't need to changed, but configurable anyways
-default[:mongodb][:mms_agent][:install_url] = 'https://mms.mongodb.com/settings/mms-monitoring-agent.zip'
-# N.B. the dir MUST be named mms-agent; this is the contents of the unarchived zip
-# the location of the dir (i.e. /usr/local/share) can be freely changed
-default[:mongodb][:mms_agent][:install_dir] = '/usr/local/share/mms-agent'
-default[:mongodb][:mms_agent][:log_dir] = File.join(File.dirname(node[:mongodb][:config][:logpath]), 'agent')
-default[:mongodb][:mms_agent][:install_munin] = true
-# this is the debian package name
-default[:mongodb][:mms_agent][:munin_package] = 'munin-node'
-default[:mongodb][:mms_agent][:enable_munin] = true
-
-default[:mongodb][:mms_agent][:require_valid_server_cert] = false

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,3 +1,2 @@
 default[:mongodb][:mms_agent][:monitoring][:version] = '2.0.0.17-1'
 default[:mongodb][:mms_agent][:backup][:version] = '1.4.3.28-1'
-

--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,2 +1,18 @@
 default[:mongodb][:mms_agent][:monitoring][:version] = '2.0.0.17-1'
 default[:mongodb][:mms_agent][:backup][:version] = '1.4.3.28-1'
+
+# deprecated attributes for mms_agent recipe
+
+default[:mongodb][:mms_agent][:mms_server] = 'https://mms.mongodb.com'
+# shouldn't need to changed, but configurable anyways
+default[:mongodb][:mms_agent][:install_url] = 'https://mms.mongodb.com/settings/mms-monitoring-agent.zip'
+# N.B. the dir MUST be named mms-agent; this is the contents of the unarchived zip
+# the location of the dir (i.e. /usr/local/share) can be freely changed
+default[:mongodb][:mms_agent][:install_dir] = '/usr/local/share/mms-agent'
+default[:mongodb][:mms_agent][:log_dir] = File.join(File.dirname(node[:mongodb][:config][:logpath]), 'agent')
+default[:mongodb][:mms_agent][:install_munin] = true
+# this is the debian package name
+default[:mongodb][:mms_agent][:munin_package] = 'munin-node'
+default[:mongodb][:mms_agent][:enable_munin] = true
+
+default[:mongodb][:mms_agent][:require_valid_server_cert] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -115,7 +115,7 @@ attribute 'mongodb/mms_agent/monitoring',
 attribute 'mongodb/mms_agent/monitoring/version',
           :display_name => 'MMS Monitoring Agent version',
           :description => 'Version of MMS Monitoring Agent to install',
-          :default => nil
+          :default => '2.0.0.17-1'
 
 attribute 'mongodb/mms_agent/backup',
           :display_name => 'MMS Backup Agent',
@@ -125,7 +125,7 @@ attribute 'mongodb/mms_agent/backup',
 attribute 'mongodb/mms_agent/backup/version',
           :display_name => 'MMS Backup Agent version',
           :description => 'Version of MMS Backup Agent to install',
-          :default => nil
+          :default => '1.4.3.28-1'
 
 attribute 'mongodb/oplog_size',
           :display_name => 'oplogSize',

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,14 +11,15 @@ recipe 'mongodb::mongos', 'Installs and configures a mongos which can be used in
 recipe 'mongodb::configserver', 'Installs and configures a configserver for mongodb sharding'
 recipe 'mongodb::shard', 'Installs and configures a single shard'
 recipe 'mongodb::replicaset', 'Installs and configures a mongodb replicaset'
-recipe 'mongodb::mms-agent', 'Installs and configures a Mongo Management Service agent'
+recipe 'mongodb::mms_monitoring_agent', 'Installs and configures a MongoDB MMS Monitoring Agent'
+recipe 'mongodb::mms_backup_agent', 'Installs and configures a MongoDB MMS Backup Agent'
 
 depends 'apt', '>= 1.8.2'
 depends 'python', '>= 1.3.0'
 depends 'runit', '>= 1.1.6'
 depends 'yum'
 
-%w{ ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|
+%w{ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|
   supports os
 end
 
@@ -103,13 +104,28 @@ attribute 'mongodb/mms_agent',
           :type => 'hash'
 
 attribute 'mongodb/mms_agent/api_key',
-          :display_name => 'MMS Agent API Key'
+          :display_name => 'MMS Agent API Key',
+          :default => nil
 
-attribute 'mongodb/mms_agent/mm_server',
-          :display_name => 'MMS Server'
+attribute 'mongodb/mms_agent/monitoring',
+          :display_name => 'MMS Monitoring Agent',
+          :description => 'Hash of MMS Monitoring Agent attributes',
+          :type => 'hash'
 
-attribute 'mongodb/mms_agent/require_valid_server_cert',
-          :display_name => 'Require valid certificate from server'
+attribute 'mongodb/mms_agent/monitoring/version',
+          :display_name => 'MMS Monitoring Agent version',
+          :description => 'Version of MMS Monitoring Agent to install',
+          :default => nil
+
+attribute 'mongodb/mms_agent/backup',
+          :display_name => 'MMS Backup Agent',
+          :description => 'Hash of MMS Backup Agent attributes',
+          :type => 'hash'
+
+attribute 'mongodb/mms_agent/backup/version',
+          :display_name => 'MMS Backup Agent version',
+          :description => 'Version of MMS Backup Agent to install',
+          :default => nil
 
 attribute 'mongodb/oplog_size',
           :display_name => 'oplogSize',

--- a/recipes/mms_backup_agent.rb
+++ b/recipes/mms_backup_agent.rb
@@ -1,0 +1,53 @@
+arch = node[:kernel][:machine]
+package = 'https://mms.mongodb.com/download/agent/backup/mongodb-mms-backup-agent'
+
+if node.platform_family?('debian')
+  arch = 'amd64' if arch == 'x86_64'
+  package = "#{package}_#{node[:mongodb][:mms_agent][:backup][:version]}_#{arch}.deb"
+  provider = Chef::Provider::Package::Dpkg
+elsif node.platform_family?('rhel') then
+  package = "#{package}-#{node[:mongodb][:mms_agent][:backup][:version]}.#{arch}.rpm"
+  provider = Chef::Provider::Package::Rpm
+else
+  Chef::Log.warn('Unsupported platform family for MMS Backup Agent.')
+  return
+end
+
+remote_file "#{Chef::Config[:file_cache_path]}/mongodb-mms-monitoring-agent" do
+  source package
+end
+
+package 'mongodb-mms-backup-agent' do
+  source "#{Chef::Config[:file_cache_path]}/mongodb-mms-monitoring-agent"
+  provider provider
+end
+
+service 'mongodb-mms-backup-agent' do
+  provider Chef::Provider::Service::Upstart if node['mongodb']['apt_repo'] == 'ubuntu-upstart'
+  supports :restart => true
+  action [:start, :enable]
+end
+
+ruby_block 'update backup-agent.config' do
+  block do
+    orig_s = ''
+    open('/etc/mongodb-mms/backup-agent.config') do |f|
+      orig_s = f.read
+    end
+    s = orig_s
+    s = s.gsub(/^apiKey=.*$/, "apiKey=#{node[:mongodb][:mms_agent][:api_key]}")
+
+    node[:mongodb][:mms_agent][:backup].each do |key, value|
+      s = s.gsub(/^#{key}\s?=.*$/, "#{key}=#{value}") unless key == 'version'
+    end
+
+    if s != orig_s
+      Chef::Log.debug 'Settings changed, overwriting and restarting service'
+      open('/etc/mongodb-mms/backup-agent.config', 'w') do |f|
+        f.puts s
+      end
+
+      notifies :restart, resources(:service => 'mongodb-mms-backup-agent'), :delayed
+    end
+  end
+end

--- a/recipes/mms_backup_agent.rb
+++ b/recipes/mms_backup_agent.rb
@@ -30,21 +30,20 @@ end
 
 ruby_block 'update backup-agent.config' do
   block do
-    orig_s = ''
+    config = ''
     open('/etc/mongodb-mms/backup-agent.config') do |f|
-      orig_s = f.read
+      config = f.read
     end
-    s = orig_s
-    s = s.gsub(/^apiKey=.*$/, "apiKey=#{node[:mongodb][:mms_agent][:api_key]}")
+    changed = !!config.gsub!(/^apiKey\s?=.*$/, "apiKey=#{node[:mongodb][:mms_agent][:api_key]}")
 
     node[:mongodb][:mms_agent][:backup].each do |key, value|
-      s = s.gsub(/^#{key}\s?=.*$/, "#{key}=#{value}") unless key == 'version'
+      (changed = !!config.gsub!(/^#{key}\s?=.*$/, "#{key}=#{value}") || changed) unless key == 'version'
     end
 
-    if s != orig_s
+    if changed
       Chef::Log.debug 'Settings changed, overwriting and restarting service'
       open('/etc/mongodb-mms/backup-agent.config', 'w') do |f|
-        f.puts s
+        f.puts config
       end
 
       notifies :restart, resources(:service => 'mongodb-mms-backup-agent'), :delayed

--- a/recipes/mms_monitoring_agent.rb
+++ b/recipes/mms_monitoring_agent.rb
@@ -1,0 +1,53 @@
+arch = node[:kernel][:machine]
+package = 'https://mms.mongodb.com/download/agent/monitoring/mongodb-mms-monitoring-agent'
+
+if node.platform_family?('debian')
+  arch = 'amd64' if arch == 'x86_64'
+  package = "#{package}_#{node[:mongodb][:mms_agent][:monitoring][:version]}_#{arch}.deb"
+  provider = Chef::Provider::Package::Dpkg
+elsif node.platform_family?('rhel') then
+  package = "#{package}-#{node[:mongodb][:mms_agent][:monitoring][:version]}.#{arch}.rpm"
+  provider = Chef::Provider::Package::Rpm
+else
+  Chef::Log.warn('Unsupported platform family for MMS Monitoring Agent.')
+  return
+end
+
+remote_file "#{Chef::Config[:file_cache_path]}/mongodb-mms-monitoring-agent" do
+  source package
+end
+
+package 'mongodb-mms-monitoring-agent' do
+  source "#{Chef::Config[:file_cache_path]}/mongodb-mms-monitoring-agent"
+  provider provider
+end
+
+service 'mongodb-mms-monitoring-agent' do
+  provider Chef::Provider::Service::Upstart if node['mongodb']['apt_repo'] == 'ubuntu-upstart'
+  supports :restart => true
+  action [:start, :enable]
+end
+
+ruby_block 'update monitoring-agent.config' do
+  block do
+    orig_s = ''
+    open('/etc/mongodb-mms/monitoring-agent.config') do |f|
+      orig_s = f.read
+    end
+    s = orig_s
+    s = s.gsub(/^mmsApiKey=.*$/, "mmsApiKey=#{node[:mongodb][:mms_agent][:api_key]}")
+
+    node[:mongodb][:mms_agent][:monitoring].each do |key, value|
+      s = s.gsub(/^#{key}\s?=.*$/, "#{key}=#{value}") unless key == 'version'
+    end
+
+    if s != orig_s
+      Chef::Log.debug 'Settings changed, overwriting and restarting service'
+      open('/etc/mongodb-mms/monitoring-agent.config', 'w') do |f|
+        f.puts s
+      end
+
+      notifies :restart, resources(:service => 'mongodb-mms-monitoring-agent'), :delayed
+    end
+  end
+end

--- a/recipes/mms_monitoring_agent.rb
+++ b/recipes/mms_monitoring_agent.rb
@@ -1,11 +1,12 @@
 arch = node[:kernel][:machine]
 package = 'https://mms.mongodb.com/download/agent/monitoring/mongodb-mms-monitoring-agent'
 
-if node.platform_family?('debian')
+case node.platform_family
+when 'debian'
   arch = 'amd64' if arch == 'x86_64'
   package = "#{package}_#{node[:mongodb][:mms_agent][:monitoring][:version]}_#{arch}.deb"
   provider = Chef::Provider::Package::Dpkg
-elsif node.platform_family?('rhel') then
+when 'rhel'
   package = "#{package}-#{node[:mongodb][:mms_agent][:monitoring][:version]}.#{arch}.rpm"
   provider = Chef::Provider::Package::Rpm
 else
@@ -35,10 +36,12 @@ ruby_block 'update monitoring-agent.config' do
     open('/etc/mongodb-mms/monitoring-agent.config') do |f|
       config = f.read
     end
-    api_key = "#{node[:mongodb][:mms_agent][:api_key]}"
+    api_key = node[:mongodb][:mms_agent][:api_key]
+    # replace mmsApiKey, optionally followed by a space, followed by an equal sign, and not followed by the api_key
     changed = !!config.gsub!(/^mmsApiKey\s?=(?!#{api_key})$/, "mmsApiKey=#{api_key}")
 
     node[:mongodb][:mms_agent][:monitoring].each do |key, value|
+      # replace key, optionally followed by a space, followed by an equal sign, and not followed by the value
       (changed = !!config.gsub!(/^#{key}\s?=(?!#{value}).*$/, "#{key}=#{value}") || changed) unless key == 'version'
     end
 

--- a/test/integration/mms_backup_agent/bats/default.bats
+++ b/test/integration/mms_backup_agent/bats/default.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+@test "starts mms backup agent" {
+    # should return a 0 status code if monitoring agent is running
+    run service mongodb-mms-backup-agent status
+    [ "$status" -eq 0 ]
+}
+
+@test "sets sslRequireValidServerCertificates to false" {
+    run grep "sslRequireValidServerCertificates=false" /etc/mongodb-mms/backup-agent.config
+    [ "$status" -eq 0 ]
+}

--- a/test/integration/mms_backup_agent/bats/default.bats
+++ b/test/integration/mms_backup_agent/bats/default.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "starts mms backup agent" {
-    # should return a 0 status code if monitoring agent is running
+    # should return a 0 status code if backup agent is running
     run service mongodb-mms-backup-agent status
     [ "$status" -eq 0 ]
 }

--- a/test/integration/mms_monitoring_agent/bats/default.bats
+++ b/test/integration/mms_monitoring_agent/bats/default.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+@test "starts mms monitoring agent" {
+    # should return a 0 status code if monitoring agent is running
+    run service mongodb-mms-monitoring-agent status
+    [ "$status" -eq 0 ]
+}
+
+@test "sets sslRequireValidServerCertificates to false" {
+    run grep "sslRequireValidServerCertificates=false" /etc/mongodb-mms/monitoring-agent.config
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
For #260.

I left the existing mms_agent recipe in place for now, in case the old tar.gz is still available. The new tar.gz alternative contains only a binary and config file and won't be compatible with mms_agent.

These new recipes pass kitchen on Ubuntu 12.04 and CentOS 6.5, but not the others for various reasons:
- On Ubuntu 10.04 the version of upstart doesn't support `setuid` in the config file
- On Debian 7.2.0 because the package expects upstart to be present but it is not
- On CentOS 5.10 because the package doesn't create the user

On Monday I plan to use these to spin up a real server for our QA environment.

Clearly the two recipes are near duplicates, and so need to be refactored. But I wanted to get this out for initial review.
