### PR TITLE
Set the log path, config path, data path to the default 10 gen repo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For examples see the USAGE section below.
 
 Basically all settings defined in the Configuration File Options documentation page can be added to the `mongodb[:config][:<setting>]` attribute: http://docs.mongodb.org/manual/reference/configuration-options/
 
-* `mongodb[:config][:dbpath]` - Location for mongodb data directory, defaults to "/var/lib/mongodb"
+* `mongodb[:config][:dbpath]` - Location for mongodb data directory, defaults to "/var/lib/mongo"
 * `mongodb[:config][:logpath]` - Path for the logfiles, default is "/var/log/mongo/mongod.log"
 * `mongodb[:config][:port]` - Port the mongod listens on, default is 27017
 * `mongodb[:config][:rest]` - Enable the ReST interface of the webserver

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ For examples see the USAGE section below.
 
 # ATTRIBUTES:
 
-## Mongodb Configuration 
+## Mongodb Configuration
 
-Basically all settings defined in the Configuration File Options documentation page can be added to the `mongodb[:config][:<setting>]` attribute: http://docs.mongodb.org/manual/reference/configuration-options/ 
+Basically all settings defined in the Configuration File Options documentation page can be added to the `mongodb[:config][:<setting>]` attribute: http://docs.mongodb.org/manual/reference/configuration-options/
 
 * `mongodb[:config][:dbpath]` - Location for mongodb data directory, defaults to "/var/lib/mongodb"
-* `mongodb[:config][:logpath]` - Path for the logfiles, default is "/var/log/mongodb/mongodb.log"
+* `mongodb[:config][:logpath]` - Path for the logfiles, default is "/var/log/mongo/mongod.log"
 * `mongodb[:config][:port]` - Port the mongod listens on, default is 27017
 * `mongodb[:config][:rest]` - Enable the ReST interface of the webserver
 * `mongodb[:config][:smallfiles]` - Modify MongoDB to use a smaller default data file size
@@ -177,7 +177,7 @@ This is esp. important when you want to replicate shards.
 
 ## Sharding + Replication
 
-The setup is not much different to the one described above. All you have to do is adding the 
+The setup is not much different to the one described above. All you have to do is adding the
 `mongodb::replicaset` recipe to all shard nodes, and make sure that all shard
 nodes which should be in the same replicaset have the same shard name.
 

--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -6,7 +6,7 @@
 include_attribute 'mongodb::default'
 
 default['mongodb']['config']['port'] = node['mongodb']['port'] || 27017
-default['mongodb']['config']['bind_ip'] = node['mongodb']['bind_ip'] || '0.0.0.0'
+default['mongodb']['config']['bind_ip'] = node['mongodb']['bind_ip'] || nil
 default['mongodb']['config']['logpath'] = File.join(node['mongodb']['logpath'] || '/var/log/mongo', 'mongod.log')
 default['mongodb']['config']['logappend'] = true
 # The platform_family? syntax in attributes files was added in Chef 11
@@ -18,9 +18,9 @@ else
   default['mongodb']['config']['fork'] = false
 end
 default['mongodb']['config']['dbpath'] = node['mongodb']['dbpath'] || '/var/lib/mongo'
-default['mongodb']['config']['nojournal'] = node['mongodb']['nojournal'] || false
-default['mongodb']['config']['rest'] = node['mongodb']['enable_rest'] || false
-default['mongodb']['config']['smallfiles'] = node['mongodb']['smallfiles'] || false
+default['mongodb']['config']['nojournal'] = node['mongodb']['nojournal'] || nil
+default['mongodb']['config']['rest'] = node['mongodb']['enable_rest'] || nil
+default['mongodb']['config']['smallfiles'] = node['mongodb']['smallfiles'] || nil
 default['mongodb']['config']['oplogSize'] = node['mongodb']['oplog_size'] || nil
 
 default['mongodb']['config']['replSet'] = node['mongodb']['replicaset_name'] || nil

--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -7,7 +7,7 @@ include_attribute 'mongodb::default'
 
 default['mongodb']['config']['port'] = node['mongodb']['port'] || 27017
 default['mongodb']['config']['bind_ip'] = node['mongodb']['bind_ip'] || '0.0.0.0'
-default['mongodb']['config']['logpath'] = File.join(node['mongodb']['logpath'] || '/var/log/mongodb', 'mongodb.log')
+default['mongodb']['config']['logpath'] = File.join(node['mongodb']['logpath'] || '/var/log/mongo', 'mongod.log')
 default['mongodb']['config']['logappend'] = true
 # The platform_family? syntax in attributes files was added in Chef 11
 # if node.platform_family?("rhel", "fedora") then

--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -17,7 +17,7 @@ when 'rhel', 'fedora'
 else
   default['mongodb']['config']['fork'] = false
 end
-default['mongodb']['config']['dbpath'] = node['mongodb']['dbpath'] || '/var/lib/mongodb'
+default['mongodb']['config']['dbpath'] = node['mongodb']['dbpath'] || '/var/lib/mongo'
 default['mongodb']['config']['nojournal'] = node['mongodb']['nojournal'] || false
 default['mongodb']['config']['rest'] = node['mongodb']['enable_rest'] || false
 default['mongodb']['config']['smallfiles'] = node['mongodb']['smallfiles'] || false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,7 +44,7 @@ default[:mongodb][:group] = 'mongodb'
 
 default[:mongodb][:init_dir] = '/etc/init.d'
 default[:mongodb][:init_script_template] = 'debian-mongodb.init.erb'
-default[:mongodb][:sysconfig_file] = '/etc/default/mongodb'
+default[:mongodb][:sysconfig_file] = '/etc/default/mongod'
 default[:mongodb][:sysconfig_file_template] = 'mongodb.sysconfig.erb'
 default[:mongodb][:dbconfig_file_template] = 'mongodb.conf.erb'
 default[:mongodb][:dbconfig_file] = '/etc/mongod.conf'
@@ -65,7 +65,7 @@ default[:mongodb][:reload_action] = 'restart' # or "nothing"
 case node['platform_family']
 when 'freebsd'
   default[:mongodb][:package_name] = 'mongo-10gen-server'
-  default[:mongodb][:sysconfig_file] = '/etc/rc.conf.d/mongodb'
+  default[:mongodb][:sysconfig_file] = '/etc/rc.conf.d/mongod'
   default[:mongodb][:init_dir] = '/usr/local/etc/rc.d'
   default[:mongodb][:root_group] = 'wheel'
 when 'rhel', 'fedora'
@@ -73,7 +73,7 @@ when 'rhel', 'fedora'
   # from http://rpm.pbone.net/index.php3?stat=3&limit=1&srodzaj=3&dl=40&search=mongodb
   # verified for RHEL5,6 Fedora 18,19
   default[:mongodb][:package_name] = 'mongodb-server'
-  default[:mongodb][:sysconfig_file] = '/etc/sysconfig/mongodb'
+  default[:mongodb][:sysconfig_file] = '/etc/sysconfig/mongod'
   default[:mongodb][:user] = 'mongod'
   default[:mongodb][:group] = 'mongod'
   default[:mongodb][:init_script_template] = 'redhat-mongodb.init.erb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ default[:mongodb][:init_script_template] = 'debian-mongodb.init.erb'
 default[:mongodb][:sysconfig_file] = '/etc/default/mongodb'
 default[:mongodb][:sysconfig_file_template] = 'mongodb.sysconfig.erb'
 default[:mongodb][:dbconfig_file_template] = 'mongodb.conf.erb'
-default[:mongodb][:dbconfig_file] = '/etc/mongodb.conf'
+default[:mongodb][:dbconfig_file] = '/etc/mongod.conf'
 default[:mongodb][:package_name] = 'mongodb'
 
 default[:mongodb][:default_init_name] = 'mongodb'

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -22,7 +22,7 @@
 define :mongodb_instance,
        :mongodb_type  => 'mongod',
        :action        => [:enable, :start],
-       :logpath       => '/var/log/mongodb/mongodb.log',
+       :logpath       => '/var/log/mongo/mongod.log',
        :dbpath        => '/data',
        :configservers => [],
        :replicaset    => nil,

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,7 +25,7 @@ end
 attribute 'mongodb/config/dbpath',
           :display_name => 'dbpath',
           :description => 'Path to store the mongodb data',
-          :default => '/var/lib/mongodb'
+          :default => '/var/lib/mongo'
 
 attribute 'mongodb/config/logpath',
           :display_name => 'logpath',

--- a/metadata.rb
+++ b/metadata.rb
@@ -30,7 +30,7 @@ attribute 'mongodb/config/dbpath',
 attribute 'mongodb/config/logpath',
           :display_name => 'logpath',
           :description => 'Path to store the logfiles of a mongodb instance',
-          :default => '/var/log/mongodb/mongodb.log'
+          :default => '/var/log/mongo/mongod.log'
 
 attribute 'mongodb/config/port',
           :display_name => 'Port',

--- a/templates/freebsd/mongodb.init.erb
+++ b/templates/freebsd/mongodb.init.erb
@@ -11,7 +11,7 @@
 #               Set it to YES to enable mongod.
 #
 # Additional configurable variables:
-# <%= @provides %>_config (path):   Set to /usr/local/etc/mongodb.conf
+# <%= @provides %>_config (path):   Set to /usr/local/etc/mongod.conf
 #               by default. Additional configuration. You
 #               can also use mongod_flags for additional
 #               command line arguments.
@@ -28,7 +28,7 @@ command=/usr/local/bin/mongod
 load_rc_config $name
 
 : ${<%= @provides %>_enable="NO"}
-: ${<%= @provides %>_config="/usr/local/etc/mongodb.conf"}
+: ${<%= @provides %>_config="/usr/local/etc/mongod.conf"}
 : ${<%= @provides %>_dbpath="/var/db/mongodb"}
 : ${<%= @provides %>_user="mongodb"}
 : ${<%= @provides %>_command_args=""}

--- a/test/unit/dbconfig_spec.rb
+++ b/test/unit/dbconfig_spec.rb
@@ -12,7 +12,7 @@ describe 'mongodb::default' do
     expect(chef_run).to enable_service 'mongodb'
 
     expect(chef_run.node['mongodb']['config']['dbpath']).to eq('/disk/mongodb/data')
-    expect(chef_run.node['mongodb']['config']['dbpath']).to_not eq('/var/lib/mongodb')
+    expect(chef_run.node['mongodb']['config']['dbpath']).to_not eq('/var/lib/mongo')
 
     expect(chef_run.node['mongodb']['config']['logpath']).to eq('/logs/mongo/mongod.log')
     expect(chef_run.node['mongodb']['config']['logpath']).to_not eq('/var/log/mongo/mongod.log')

--- a/test/unit/dbconfig_spec.rb
+++ b/test/unit/dbconfig_spec.rb
@@ -14,7 +14,7 @@ describe 'mongodb::default' do
     expect(chef_run.node['mongodb']['config']['dbpath']).to eq('/disk/mongodb/data')
     expect(chef_run.node['mongodb']['config']['dbpath']).to_not eq('/var/lib/mongodb')
 
-    expect(chef_run.node['mongodb']['config']['logpath']).to eq('/logs/mongodb/mongodb.log')
-    expect(chef_run.node['mongodb']['config']['logpath']).to_not eq('/var/log/mongodb/mongodb.log')
+    expect(chef_run.node['mongodb']['config']['logpath']).to eq('/logs/mongo/mongod.log')
+    expect(chef_run.node['mongodb']['config']['logpath']).to_not eq('/var/log/mongo/mongod.log')
   end
 end


### PR DESCRIPTION
When we chef solo this cookbook, we will get duplicated mongo log, config file, and data dir and it's quite frustrating.
I am not sure why you will use different paths for these.
So I changed: 

Config
/etc/mongodb.conf -> /etc/mongod.conf
Log
/var/log/mongodb/mongodb.log -> /var/log/mongo/mongod.log
Data
/var/lib/mongodb -> /var/lib/mongo

Also, with latest mongo (2.9.x), we will see warnings when we start the mongo:

```
Starting mongod: 
warning: remove or comment out this line by starting it with '#', skipping now : nojournal = false
warning: remove or comment out this line by starting it with '#', skipping now : rest = false
warning: remove or comment out this line by starting it with '#', skipping now : smallfiles = false
warning: bind_ip of 0.0.0.0 is unnecessary; listens on all ips by default
```

So I set the default value of `nojournal`, `rest`, `smallfiles`, and `bind_ip` to `nil`.
