### PR TITLE
only fail monogos recipe due to negative node search if the configdb is ...

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -91,6 +91,8 @@ suites:
   attributes:
     mongodb:
       cluster_name: default
+      config:
+        configdb: my_configserver
 
 - name: mms_agent
   run_list:

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -38,8 +38,8 @@ configsrvs = search(
 )
 
 if configsrvs.length != 1 && configsrvs.length != 3
-  Chef::Log.error("Found #{configsrvs.length} configserver, need either one or three of them")
-  fail 'Wrong number of configserver nodes'
+  Chef::Log.error("Found #{configsrvs.length} configservers, need either one or three of them")
+  fail 'Wrong number of configserver nodes' unless node['mongodb']['config']['configdb']
 end
 
 mongodb_instance node['mongodb']['instance_name'] do

--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -39,7 +39,7 @@ configsrvs = search(
 
 if configsrvs.length != 1 && configsrvs.length != 3
   Chef::Log.error("Found #{configsrvs.length} configservers, need either one or three of them")
-  fail 'Wrong number of configserver nodes' unless node['mongodb']['config']['configdb']
+  fail 'Wrong number of configserver nodes' unless Chef::Config[:solo]
 end
 
 mongodb_instance node['mongodb']['instance_name'] do


### PR DESCRIPTION
...not explicitly configured; set the configdb explicitly so that kitchen can pass
