### PR TITLE
Call the cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,13 @@ NumericLiterals:
 
 Encoding:
   Enabled: false # TODO: enable (?)
+
+FileName:
+  Exclude:
+    - mms-agent.rb
+
+ClassAndModuleChildren:
+  EnforcedStyle: compact
+
+DoubleNegation:
+  Enabled: false # TODO: mms agent recipes could be improved to not use double negation

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'berkshelf',  '~> 2.0'
 gem 'chefspec',   '~> 3.0'
 # gem 'foodcritic', '~> 3.0'
 gem 'rake',       '~> 10.1'
-gem 'rubocop',    '~> 0.16'
+gem 'rubocop',    '~> 0.18.1'
 
 group :integration do
     gem 'test-kitchen',    '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'berkshelf',  '~> 2.0'
 gem 'chefspec',   '~> 3.0'
 # gem 'foodcritic', '~> 3.0'
 gem 'rake',       '~> 10.1'
-gem 'rubocop',    '~> 0.18.1'
+gem 'rubocop',    '~> 0.19.0'
 
 group :integration do
     gem 'test-kitchen',    '~> 1.2'

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,8 @@ Rubocop::RakeTask.new(:rubocop) do |task|
   # only show the files with failures
   #task.formatters = ['files']
   # don't abort rake on failure
-  task.fail_on_error = true
+  task.fail_on_error = false
+  task.options = ['-D']
 end
 
 begin

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -107,6 +107,6 @@ default[:mongodb][:key_file_content] = nil
 # install the mongo and bson_ext ruby gems at compile time to make them globally available
 # TODO: remove bson_ext once mongo gem supports bson >= 2
 default['mongodb']['ruby_gems'] = {
-    :mongo => nil,
-    :bson_ext => nil
+  :mongo => nil,
+  :bson_ext => nil
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,7 +87,7 @@ when 'rhel', 'fedora'
     default[:mongodb][:install_method] = '10gen'
     default[:mongodb][:package_name] = 'mongo-10gen-server'
   end
-when "debian"
+when 'debian'
   if node['platform'] == 'ubuntu'
     default[:mongodb][:apt_repo] = 'ubuntu-upstart'
     default[:mongodb][:init_dir] = '/etc/init/'
@@ -96,8 +96,8 @@ when "debian"
     default[:mongodb][:apt_repo] = 'debian-sysvinit'
   end
 else
-    Chef::Log.error("Unsupported Platform Family: #{node['platform_family']}")
-    fail
+  Chef::Log.error("Unsupported Platform Family: #{node['platform_family']}")
+  fail
 end
 
 default[:mongodb][:template_cookbook] = 'mongodb'

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -29,7 +29,7 @@ define :mongodb_instance,
        :notifies      => [] do
 
   # TODO: this is the only remain use of params[:mongodb_type], is it still needed?
-  unless %w[mongod shard configserver mongos].include?(params[:mongodb_type])
+  unless %w(mongod shard configserver mongos).include?(params[:mongodb_type])
     fail ArgumentError, ":mongodb_type must be 'mongod', 'shard', 'configserver' or 'mongos'; was #{params[:mongodb_type].inspect}"
   end
 

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -86,8 +86,8 @@ class Chef::ResourceDefinitionList::MongoDB
     admin = connection['admin']
     cmd = BSON::OrderedHash.new
     cmd['replSetInitiate'] = {
-        '_id' => name,
-        'members' => rs_members
+      '_id' => name,
+      'members' => rs_members
     }
 
     begin
@@ -142,7 +142,7 @@ class Chef::ResourceDefinitionList::MongoDB
         begin
           result = admin.command(cmd, :check_response => false)
         rescue Mongo::ConnectionFailure
-          # reconfiguring destroys exisiting connections, reconnect
+          # reconfiguring destroys existing connections, reconnect
           connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5, :slave_ok => true)
           config = connection['local']['system']['replset'].find_one('_id' => name)
           # Validate configuration change
@@ -187,7 +187,7 @@ class Chef::ResourceDefinitionList::MongoDB
         begin
           result = admin.command(cmd, :check_response => false)
         rescue Mongo::ConnectionFailure
-          # reconfiguring destroys exisiting connections, reconnect
+          # reconfiguring destroys existing connections, reconnect
           connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5, :slave_ok => true)
           config = connection['local']['system']['replset'].find_one('_id' => name)
           # Validate configuration change

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,7 @@ depends 'yum', '< 3.0'
 depends 'python', '< 1.4.6'
 depends 'runit', '< 1.5.0'
 
-%w{ubuntu debian freebsd centos redhat fedora amazon scientific}.each do |os|
+%w(ubuntu debian freebsd centos redhat fedora amazon scientific).each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,13 +26,13 @@ allow_mongodb_instance_run = true
 conflicting_recipes = %w{mongodb::replicaset mongodb::shard mongodb::configserver mongodb::mongos mongodb::mms_agent}
 chef_major_version = Chef::VERSION.split('.').first.to_i
 if chef_major_version < 11
-  conflicting_recipes.each { |recipe|
+  conflicting_recipes.each do |recipe|
     allow_mongodb_instance_run &&= false if node.recipe?(recipe)
-  }
+  end
 else
-  conflicting_recipes.each { |recipe|
+  conflicting_recipes.each do |recipe|
     allow_mongodb_instance_run &&= false if node.run_context.loaded_recipe?(recipe)
-  }
+  end
 end
 
 if allow_mongodb_instance_run

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ include_recipe 'mongodb::install'
 
 # allow mongodb_instance to run if recipe isn't included
 allow_mongodb_instance_run = true
-conflicting_recipes = %w{mongodb::replicaset mongodb::shard mongodb::configserver mongodb::mongos mongodb::mms_agent}
+conflicting_recipes = %w(mongodb::replicaset mongodb::shard mongodb::configserver mongodb::mongos mongodb::mms_agent)
 chef_major_version = Chef::VERSION.split('.').first.to_i
 if chef_major_version < 11
   conflicting_recipes.each do |recipe|

--- a/recipes/mms_agent.rb
+++ b/recipes/mms_agent.rb
@@ -8,9 +8,7 @@
 #
 #
 
-if node['mongodb']['mms_agent']['api_key'].nil?
-  Chef::Log.warn 'Found empty mms_agent.api_key attribute'
-end
+Chef::Log.warn 'Found empty mms_agent.api_key attribute' if node['mongodb']['mms_agent']['api_key'].nil?
 
 require 'fileutils'
 include_recipe 'python'

--- a/recipes/mms_backup_agent.rb
+++ b/recipes/mms_backup_agent.rb
@@ -1,3 +1,5 @@
+Chef::Log.warn 'Found empty mms_agent.api_key attribute' if node['mongodb']['mms_agent']['api_key'].nil?
+
 arch = node[:kernel][:machine]
 package = 'https://mms.mongodb.com/download/agent/backup/mongodb-mms-backup-agent'
 

--- a/recipes/mms_monitoring_agent.rb
+++ b/recipes/mms_monitoring_agent.rb
@@ -1,3 +1,5 @@
+Chef::Log.warn 'Found empty mms_agent.api_key attribute' if node['mongodb']['mms_agent']['api_key'].nil?
+
 arch = node[:kernel][:machine]
 package = 'https://mms.mongodb.com/download/agent/monitoring/mongodb-mms-monitoring-agent'
 

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -1,7 +1,7 @@
 chef_major_version = Chef::VERSION.split('.')[0].to_i
 chef_minor_version = Chef::VERSION.split('.')[1].to_i
 node['mongodb']['ruby_gems'].each do |gem, version|
-  if chef_major_version < 10 and chef_minor_version < 12
+  if chef_major_version < 10 && chef_minor_version < 12
     gem_package gem do
       version version
       action :nothing

--- a/test/unit/mms_agent_spec.rb
+++ b/test/unit/mms_agent_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-describe 'mongodb::mms-agent' do
+describe 'mongodb::mms_agent' do
   let(:chef_run) do
     stub_command("/usr/bin/python -c 'import setuptools'").and_return(true)
     ChefSpec::Runner.new(:platform => 'ubuntu', :version => '12.04') do |n|


### PR DESCRIPTION
With rubocop specified at 0.16, everything up to but not including 1.0.0 would be pulled. This will cause failures over time. We should update versions when we are prepared to configure the cops or update the code.

Update to latest 0.19.x and address violations.
