### PR TITLE
mms fix dpkg install

### DIFF
--- a/attributes/mms_agent.rb
+++ b/attributes/mms_agent.rb
@@ -1,5 +1,5 @@
-default[:mongodb][:mms_agent][:monitoring][:version] = '2.0.0.17-1'
-default[:mongodb][:mms_agent][:backup][:version] = '1.4.3.28-1'
+default[:mongodb][:mms_agent][:monitoring][:version] = '2.1.0.35-1'
+default[:mongodb][:mms_agent][:backup][:version] = '1.4.4.34-1'
 
 # deprecated attributes for mms_agent recipe
 

--- a/recipes/mms_backup_agent.rb
+++ b/recipes/mms_backup_agent.rb
@@ -2,12 +2,15 @@ Chef::Log.warn 'Found empty mms_agent.api_key attribute' if node['mongodb']['mms
 
 arch = node[:kernel][:machine]
 package = 'https://mms.mongodb.com/download/agent/backup/mongodb-mms-backup-agent'
+package_opts = ''
 
 case node.platform_family
 when 'debian'
   arch = 'amd64' if arch == 'x86_64'
   package = "#{package}_#{node[:mongodb][:mms_agent][:backup][:version]}_#{arch}.deb"
   provider = Chef::Provider::Package::Dpkg
+  # Without this, if the package changes the config files that we rewrite install fails
+  package_opts = '--force-confold'
 when 'rhel'
   package = "#{package}-#{node[:mongodb][:mms_agent][:backup][:version]}.#{arch}.rpm"
   provider = Chef::Provider::Package::Rpm
@@ -23,6 +26,7 @@ end
 package 'mongodb-mms-backup-agent' do
   source "#{Chef::Config[:file_cache_path]}/mongodb-mms-monitoring-agent"
   provider provider
+  options package_opts
 end
 
 service 'mongodb-mms-backup-agent' do

--- a/recipes/mms_monitoring_agent.rb
+++ b/recipes/mms_monitoring_agent.rb
@@ -2,12 +2,15 @@ Chef::Log.warn 'Found empty mms_agent.api_key attribute' if node['mongodb']['mms
 
 arch = node[:kernel][:machine]
 package = 'https://mms.mongodb.com/download/agent/monitoring/mongodb-mms-monitoring-agent'
+package_opts = ''
 
 case node.platform_family
 when 'debian'
   arch = 'amd64' if arch == 'x86_64'
   package = "#{package}_#{node[:mongodb][:mms_agent][:monitoring][:version]}_#{arch}.deb"
   provider = Chef::Provider::Package::Dpkg
+  # Without this, if the package changes the config files that we rewrite install fails
+  package_opts = '--force-confold'
 when 'rhel'
   package = "#{package}-#{node[:mongodb][:mms_agent][:monitoring][:version]}.#{arch}.rpm"
   provider = Chef::Provider::Package::Rpm
@@ -23,6 +26,7 @@ end
 package 'mongodb-mms-monitoring-agent' do
   source "#{Chef::Config[:file_cache_path]}/mongodb-mms-monitoring-agent"
   provider provider
+  options package_opts
 end
 
 service 'mongodb-mms-monitoring-agent' do


### PR DESCRIPTION
if the MongoDB package changes the config file, dpkg install fails if you already have an older version installed

also, bump to latest agent versions
