### PR TITLE
Update 10gen_repo.rb

### DIFF
--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -42,6 +42,15 @@ when 'rhel', 'fedora'
     action :add
   end
   node.override['mongodb']['package_name'] = 'mongo-10gen-server'
+  
+when 'amazon'
+  yum_repository '10gen' do
+    description '10gen RPM Repository'
+    url "http://downloads-distro.mongodb.org/repo/redhat/os/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
+    action :add
+    gpgcheck false
+  end
+  node.override['mongodb']['package_name'] = 'mongo-10gen-server'
 
 else
   # pssst build from source


### PR DESCRIPTION
On amazon linux, Chef would error out.  After a _lot_ of debugging, the I found that the yum_repository LWRP was trying to execute `yum -d0 -e0 -y install mongo-10gen-server-2.4.9-mongodb_1`.  This yielded errors indicating that installation could not proceed because the package was not signed.

In the `/etc/yum.repos.d/10gen.repo` file a `gpgcheck=0` directive must be added; this is not the default `yum_repository` behavior. I was unable to get the `mongodb::default` recipe to install mongo until I manually changed the `10gen.repo` file to read as

```
[10gen]
name=10gen Repository
baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64
gpgcheck=0
```
