### PR TITLE
Install gcc on centos so that native extensions can be built

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,10 +70,6 @@ suites:
   excludes:
     # Upstart is not starting mongodb, status script returns 0 and there are no useful logs. wat?
     - ubuntu-10.04
-    # bson_ext fails to install
-    - centos-6.5
-    # bson_ext fails to install
-    - centos-5.10
 
 - name: configserver
   run_list:

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -1,16 +1,13 @@
-chef_major_version = Chef::VERSION.split('.')[0].to_i
-chef_minor_version = Chef::VERSION.split('.')[1].to_i
+# The build-essential cookbook was not running during the compile phase, install gcc explicitly for rhel so native
+# extensions can be installed
+gcc = package 'gcc' do
+  action :nothing
+  only_if { platform_family?('rhel') }
+end
+gcc.run_action(:install)
+
 node['mongodb']['ruby_gems'].each do |gem, version|
-  if chef_major_version < 10 && chef_minor_version < 12
-    gem_package gem do
-      version version
-      action :nothing
-    end.run_action(:install)
-    Gem.clear_paths
-  else
-    chef_gem gem do
-      version version
-      action :install
-    end
+  chef_gem gem do
+    version version
   end
 end

--- a/test/integration/replicaset/bats/default.bats
+++ b/test/integration/replicaset/bats/default.bats
@@ -18,5 +18,5 @@
 @test "replicaset initialized" {
     run mongo --eval "rs.status().ok"
     [ "$status" -eq 0 ]
-    [ "${lines[-1]}" -eq 1 ]
+    [ "${lines[@]:(-1)}" -eq 1 ]
 }


### PR DESCRIPTION
Failed to get build-essentials cookbook to work.
Remove support for Chef 10.
Fix bats test to support older version of bash.

Should address #277
