### PR TITLE
Update 10gen package name

### DIFF
--- a/recipes/10gen_repo.rb
+++ b/recipes/10gen_repo.rb
@@ -33,7 +33,7 @@ when 'debian'
     key '7F0CEB10'
     action :add
   end
-  node.override['mongodb']['package_name'] = 'mongodb-10gen'
+  node.override['mongodb']['package_name'] = 'mongodb-org'
 
 when 'rhel', 'fedora'
   yum_repository '10gen' do


### PR DESCRIPTION
The modern 10gen dists of mongodb use teh 'mongodb-org' package names: http://downloads-distro.mongodb.org/repo/ubuntu-upstart/dists/dist/10gen/binary-amd64/

This is also what the Ubuntu installation guide suggests: http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
