### PR TITLE
removed bogus fail

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,7 +97,6 @@ when 'debian'
   end
 else
   Chef::Log.error("Unsupported Platform Family: #{node['platform_family']}")
-  fail
 end
 
 default[:mongodb][:template_cookbook] = 'mongodb'


### PR DESCRIPTION
Attributes.rb sets default attributes according to the platform of the target node.  The mongodb cookbook intentionally fails if the platform is unknown.

This error makes sense if one is actually attempting to use this cookbook on unsupported platform.  However, the fail will cause chef to fail on windows if the mongodb cookbook is referenced but no recipes are actually used. 

This affects people using the same metadata.rb on multiple platforms in which mongo may be called for in some recipes, but not others...  
