### PR TITLE
Error while downgrading mongodb

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -52,7 +52,7 @@ case node['platform_family']
 when 'debian'
   # this options lets us bypass complaint of pre-existing init file
   # necessary until upstream fixes ENABLE_MONGOD/DB flag
-  packager_opts = '-o Dpkg::Options::="--force-confold"'
+  packager_opts = '-o Dpkg::Options::="--force-confold" --force-yes'
 when 'rhel'
   # Add --nogpgcheck option when package is signed
   # see: https://jira.mongodb.org/browse/SERVER-8770


### PR DESCRIPTION
I think this issue was brought up in #257 but when changing to an older version of mongodb with apt-get and the 10gen repo, the instance produces an error about: "E: There are problems and -y was used without --force-yes".  In the install recipe packager_opts should just have "--force-yes" added.  Or else make this configurable...
