### PR TITLE
replica: include example replica member node

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,9 +5,10 @@ driver:
     memory: 512
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
   # require_chef_omnibus: latest # will install on each run
-  require_chef_omnibus: 11.8.2
+  require_chef_omnibus: 11.12.8
+  nodes_path: test/integration/nodes
 
 platforms:
 
@@ -62,7 +63,6 @@ suites:
 
 - name: replicaset
   run_list:
-  - "recipe[chef-solo-search]"
   - "recipe[mongodb::replicaset]"
   attributes:
     mongodb:
@@ -79,7 +79,6 @@ suites:
 
 - name: mongos
   run_list:
-  - "recipe[chef-solo-search]"
   - "recipe[mongodb::mongos]"
   attributes:
     mongodb:

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,3 @@
 source "http://api.berkshelf.com"
 
 metadata
-
-cookbook 'chef-solo-search'

--- a/test/integration/nodes/mongodb-replica-001.json
+++ b/test/integration/nodes/mongodb-replica-001.json
@@ -1,0 +1,33 @@
+{
+  "id": "mongodb-replica-001",
+  "name": "mongodb-replica-001",
+  "chef_environment": "_default",
+  "json_class": "Chef::Node",
+  "automatic": {
+    "fqdn": "mongodb-replica-001.example.net",
+    "hostname": "mongodb-replica-001",
+    "os": "centos"
+  },
+  "normal": {
+    "mongodb":{
+      "cluster_name": "kitchen",
+      "is_replicaset": "true",
+      "shard_name": "default",
+      "config": {
+        "port": "1234"
+      },
+      "replica_arbiter_only": false,
+      "replica_build_indexes": true,
+      "replica_hidden": false,
+      "replica_slave_delay": 0,
+      "replica_priority": 1,
+      "replica_tags": {"foo":"bar"},
+      "replica_votes": 1
+    }
+  },
+  "chef_type": "node",
+  "default": {},
+  "override": {},
+  "run_list": []
+}
+


### PR DESCRIPTION
This is an example of how to use `node` objects with the `chef_zero` provisioner, as for #311.

Sadly it doesn't pass because replicaset initialization requires all members to be up.
