### PR TITLE
User management - fix auth attribute default

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -132,8 +132,6 @@ suites:
       # since mongo 2.6
       default_init_name: mongod
       dbconfig_file: mongodb.conf
-      config:
-        auth: true
   excludes:
     # Can't connect to mongodb without it running from upstart
     - ubuntu-10.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -132,6 +132,8 @@ suites:
       # since mongo 2.6
       default_init_name: mongod
       dbconfig_file: mongodb.conf
+      config:
+        auth: true
   excludes:
     # Can't connect to mongodb without it running from upstart
     - ubuntu-10.04

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ For more details, you can find a [tutorial for Sharding + Replication](https://g
 ### MMS Agent
 
 This cookbook also includes support for
-[MongoDB Monitoring System (MMS)](http://www.10gen.com/mongodb-monitoring-service)
+[MongoDB Monitoring System (MMS)](https://mms.mongodb.com/)
 agent. MMS is a hosted monitoring service, provided by 10gen, Inc. Once
 the small python agent program is installed on the MongoDB host, it
 automatically collects the metrics and uploads them to the MMS server.
@@ -232,7 +232,7 @@ production MongoDB deployments.
 To setup MMS, simply set your keys in
 `node['mongodb']['mms_agent']['api_key']` and then add the
 `mongodb::mms-agent` recipe to your run list. Your current keys should
-be available at your [MMS Settings page](https://mms.10gen.com/settings]).
+be available at your [MMS Settings page](https://mms.mongodb.com/settings).
 
 ### User Management
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ the configuration file by default and create any users in the `node['mongodb']['
 The users array expects a hash of username, password, roles, and database. Roles should be
 an array of roles the user should have on the database given.
 
-Ensure `node['mongodb']['config']['auth']` is set to true if you want to lock the database
-down to only authenticated users.
+If the `::user_management` recipe is included, it will enable authentication by setting
+the `node['mongodb']['config']['auth']` to true. This can be overridden in the chef json.
 
 If the auth configuration is true, it will try to create the `node['mongodb']['admin']` user, or
 update them if they already exist. Before using on a new database, ensure you're overwriting

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Basically all settings defined in the Configuration File Options documentation p
 
 ### User management attributes
 
-* `node['mongodb']['config']['auth']` - Require authentication on database
+* `node['mongodb']['config']['auth']` - Require authentication to access or modify the database
 * `node['mongodb']['admin']` - The admin user with userAdmin privileges that allows user management
 * `node['mongodb']['users']` - Array of users to add when running the user management recipe
 
@@ -211,7 +211,7 @@ This is esp. important when you want to replicate shards.
 
 ### Sharding + Replication
 
-The setup is not much different to the one described above. All you have to do is adding the 
+The setup is not much different to the one described above. All you have to do is add the
 `mongodb::replicaset` recipe to all shard nodes, and make sure that all shard
 nodes which should be in the same replicaset have the same shard name.
 
@@ -220,10 +220,10 @@ For more details, you can find a [tutorial for Sharding + Replication](https://g
 ### MMS Agent
 
 This cookbook also includes support for
-{MongoDB Monitoring System (MMS)}[http://www.10gen.com/mongodb-monitoring-service]
+[MongoDB Monitoring System (MMS)](http://www.10gen.com/mongodb-monitoring-service)
 agent. MMS is a hosted monitoring service, provided by 10gen, Inc. Once
 the small python agent program is installed on the MongoDB host, it
-automatically collects the metrics and upload them to the MMS server.
+automatically collects the metrics and uploads them to the MMS server.
 The graphs of these metrics are shown on the web page. It helps a lot
 for tackling MongoDB related problems, so MMS is the baseline for all
 production MongoDB deployments.
@@ -232,7 +232,7 @@ production MongoDB deployments.
 To setup MMS, simply set your keys in
 `node['mongodb']['mms_agent']['api_key']` and then add the
 `mongodb::mms-agent` recipe to your run list. Your current keys should
-be available at your {MMS Settings page}[https://mms.10gen.com/settings].
+be available at your [MMS Settings page](https://mms.10gen.com/settings]).
 
 ### User Management
 
@@ -240,6 +240,9 @@ An optional recipe is `mongodb::user_management` which will enable authenticatio
 the configuration file by default and create any users in the `node['mongodb']['users']`.
 The users array expects a hash of username, password, roles, and database. Roles should be
 an array of roles the user should have on the database given.
+
+Ensure `node['mongodb']['config']['auth']` is set to true if you want to lock the database
+down to only authenticated users.
 
 If the auth configuration is true, it will try to create the `node['mongodb']['admin']` user, or
 update them if they already exist. Before using on a new database, ensure you're overwriting

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -1,4 +1,6 @@
-default['mongodb']['config']['auth'] = true
+# Set this to true in your chef json
+# to require all users to authenticate
+default['mongodb']['config']['auth'] = false
 
 default['mongodb']['admin'] = {
   'username' => 'admin',

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -1,7 +1,3 @@
-# Set this to true in your chef json
-# to require all users to authenticate
-default['mongodb']['config']['auth'] = false
-
 default['mongodb']['admin'] = {
   'username' => 'admin',
   'password' => '2NCDza6MLjDUm0m',

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -1,5 +1,8 @@
 chef_gem 'mongo'
 
+# Set default to true if this recipe is included
+node.default['mongodb']['config']['auth'] = true
+
 users = []
 admin = node['mongodb']['admin']
 


### PR DESCRIPTION
When I set `node['mongodb']['config']['auth']` to true in users.rb, I was inadvertently setting it to true even when `::user_management` wasn't included. I thought I was using include_attribute or, I don't know, what I'm doing here in this PR instead.

So that had the effect of making all mongo installs require authentication, even when no users were created. Quite a big problem. This should fix that so it's only set to true if the recipe is included, but still can be overridden to false by users.
