### PR TITLE
Changing mongos service name to config variable

### DIFF
--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -26,7 +26,7 @@ node.override['mongodb']['instance_name'] = 'mongos'
 include_recipe 'mongodb::install'
 include_recipe 'mongodb::mongo_gem'
 
-service 'mongodb' do
+service node[:mongodb][:default_init_name] do
   action [:disable, :stop]
 end
 


### PR DESCRIPTION
The mongos service name was hardcoded in mongos.rb, making it fail to stop in ubuntu 12.04 since the service name is mongod and not mongodb.
