### PR TITLE
Update debian-mongodb.upstart.erb

### DIFF
--- a/templates/default/debian-mongodb.upstart.erb
+++ b/templates/default/debian-mongodb.upstart.erb
@@ -15,7 +15,7 @@ stop on runlevel [06]
 
 script
   NAME=<%= @provides %>
-  ENABLE_MONGODB="yes"
+  ENABLE_MONGOD="yes"
   if [ -f <%= @sysconfig_file %> ]; then
     . <%= @sysconfig_file %>;
   fi


### PR DESCRIPTION
Lines 18 & 22 should reference the same variable. "ENABLE_MONGOD" chosen as the proper name, as it matches what's in the 2.6.3 distribution of MongoDB on Ubuntu.
