### PR TITLE
Changes to how admin user is set up by default

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -132,6 +132,8 @@ suites:
       # since mongo 2.6
       default_init_name: mongod
       dbconfig_file: mongodb.conf
+      config:
+        auth: true
   excludes:
     # Can't connect to mongodb without it running from upstart
     - ubuntu-10.04

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ the configuration file by default and create any users in the `node['mongodb']['
 The users array expects a hash of username, password, roles, and database. Roles should be
 an array of roles the user should have on the database given.
 
-If the `::user_management` recipe is included, it will enable authentication by setting
-the `node['mongodb']['config']['auth']` to true. This can be overridden in the chef json.
+By default, authentication is not required on the database. This can be overridden by setting
+the `node['mongodb']['config']['auth']` attribute to true in the chef json.
 
 If the auth configuration is true, it will try to create the `node['mongodb']['admin']` user, or
 update them if they already exist. Before using on a new database, ensure you're overwriting

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -1,6 +1,6 @@
 default['mongodb']['admin'] = {
   'username' => 'admin',
-  'password' => '2NCDza6MLjDUm0m',
+  'password' => 'admin',
   'roles' => %w(userAdminAnyDatabase dbAdminAnyDatabase),
   'database' => 'admin'
 }

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -10,13 +10,23 @@ def add_user(username, password, roles = [], database)
   admin = connection.db('admin')
   db = connection.db(database)
 
-  # Must authenticate as a userAdmin after an admin user has been created
+  # Check if user is admin / admin, and warn that this should
+  # be overridden to unique values
+  if username == 'admin' && password == 'admin'
+    Chef::Log.warn('Default username / password detected for admin user');
+    Chef::Log.warn('These should be overridden to different, unique values');
+  end
+
+  # If authentication is required on database
+  # must authenticate as a userAdmin after an admin user has been created
   # this will fail on the first attempt, but user will still be created
   # because of the localhost exception
-  begin
-    admin.authenticate(@new_resource.connection['admin']['username'], @new_resource.connection['admin']['password'])
-  rescue Mongo::AuthenticationError => e
-    Chef::Log.warn("Unable to authenticate as admin user. If this is a fresh install, ignore warning: #{e}")
+  if node['mongodb']['config']['auth'] == true
+    begin
+      admin.authenticate(@new_resource.connection['admin']['username'], @new_resource.connection['admin']['password'])
+    rescue Mongo::AuthenticationError => e
+      Chef::Log.warn("Unable to authenticate as admin user. If this is a fresh install, ignore warning: #{e}")
+    end
   end
 
   # Create the user if they don't exist

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -1,8 +1,5 @@
 chef_gem 'mongo'
 
-# Set default to true if this recipe is included
-node.default['mongodb']['config']['auth'] = true
-
 users = []
 admin = node['mongodb']['admin']
 

--- a/test/integration/user_management/bats/default.bats
+++ b/test/integration/user_management/bats/default.bats
@@ -21,6 +21,6 @@
 }
 
 @test "admin user created" {
-    mongo admin -u admin -p 2NCDza6MLjDUm0m --eval "db.stats().ok"
+    mongo admin -u admin -p admin --eval "db.stats().ok"
     [ $? -eq 0 ]
 }


### PR DESCRIPTION
The changes we discussed in my PR commit:
- changing admin default password and warning users if still set
- updating to only attempt to authenticate if the db requires it
