### PR TITLE
Chef-Solo handling for replicaset databags

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -48,8 +48,8 @@ class Chef::ResourceDefinitionList::MongoDB
     end
 
     # Want the node originating the connection to be included in the replicaset
-    members << node unless members.any? { |m| m.name == node.name }
-    members.sort! { |x, y| x.name <=> y.name }
+    members << node unless members.any? { |m| m['name'] == node['name'] }
+    members.sort! { |x, y| x['name'] <=> y['name'] }
     rs_members = []
     rs_options = {}
     members.each_index do |n|

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -48,8 +48,15 @@ class Chef::ResourceDefinitionList::MongoDB
     end
 
     # Want the node originating the connection to be included in the replicaset
-    members << node unless members.any? { |m| m['name'] == node['name'] }
-    members.sort! { |x, y| x['name'] <=> y['name'] }
+    if Chef::Config[:solo]
+      # Specific handling for chef solo where databags are read in as
+      # array values from chef-solo-search
+      members << node unless members.any? { |m| m['name'] == node['name'] }
+      members.sort! { |x, y| x['name'] <=> y['name'] }
+    else
+      members << node unless members.any? { |m| m.name == node.name }
+      members.sort! { |x, y| x.name <=> y.name }
+    end
     rs_members = []
     rs_options = {}
     members.each_index do |n|


### PR DESCRIPTION
Just starting off, want to say I'm definitely open to discussion on this pull request as I want to make sure I'm not suggesting any changes that reduce quality. I'm also not able to test this with chef-server, only chef-solo.

Right now, I'm unable to create a replicated, sharded cluster using chef-solo. When trying to start up the first mongod server, it errors out with the following Chef output:

``` sh
==> d0: [2014-09-09T13:51:59+00:00] INFO: service[mongodb] sending create action to ruby_block[config_replicaset] (delayed)
==> d0: 
==> d0: ================================================================================
==> d0: Error executing action `create` on resource 'ruby_block[config_replicaset]'
==> d0: ================================================================================
==> d0: 
==> d0: 
==> d0: NoMethodError
==> d0: -------------
==> d0: undefined method `name' for #<Hash:0x00000003825a48>
==> d0: 
==> d0: 
==> d0: Cookbook Trace:
==> d0: ---------------
==> d0: /tmp/vagrant-chef-8/chef-solo-1/cookbooks/mongodb/libraries/mongodb.rb:51:in `block in configure_replicaset'
==> d0: 
==> d0: /tmp/vagrant-chef-8/chef-solo-1/cookbooks/mongodb/libraries/mongodb.rb:51:in `each'
==> d0: 
==> d0: /tmp/vagrant-chef-8/chef-solo-1/cookbooks/mongodb/libraries/mongodb.rb:51:in `any?'
==> d0: 
==> d0: /tmp/vagrant-chef-8/chef-solo-1/cookbooks/mongodb/libraries/mongodb.rb:51:in `configure_replicaset'
==> d0: 
==> d0: /tmp/vagrant-chef-8/chef-solo-1/cookbooks/mongodb/definitions/mongodb.rb:215:in `block (3 levels) in from_file'
```

You can see the complete example of how I'm trying to create the cluster in my [MongoDB Cluster repo](https://github.com/ceejh/mongodb-cluster). It's quite possible I'm just using chef-solo-search improperly to create the information for the nodes, so please let me know if I am.

When using the change in this pull request, all the nodes come up successfully and look configured properly. The mongos server:

```
mongos> sh.status()
--- Sharding Status --- 
  sharding version: {
    "_id" : 1,
    "version" : 4,
    "minCompatibleVersion" : 4,
    "currentVersion" : 5,
    "clusterId" : ObjectId("540f0fc37147067f945abde4")
}
  shards:
    {  "_id" : "rs_default",  "host" : "rs_default/d0:27017,d1:27017,d2:27017" }
  databases:
    {  "_id" : "admin",  "partitioned" : false,  "primary" : "config" }
    {  "_id" : "foo",  "partitioned" : true,  "primary" : "rs_default" }
        foo.bar
            shard key: { "baz" : 1 }
            chunks:
                rs_default  1
            { "baz" : { "$minKey" : 1 } } -->> { "baz" : { "$maxKey" : 1 } } on : rs_default Timestamp(1, 0) 
```

The mongod server:

```
rs_default:SECONDARY> rs.status()
{
    "set" : "rs_default",
    "date" : ISODate("2014-09-09T14:34:30Z"),
    "myState" : 2,
    "syncingTo" : "d2:27017",
    "members" : [
        {
            "_id" : 0,
            "name" : "d0:27017",
            "health" : 1,
            "state" : 2,
            "stateStr" : "SECONDARY",
            "uptime" : 302,
            "optime" : Timestamp(1410273220, 1),
            "optimeDate" : ISODate("2014-09-09T14:33:40Z"),
            "self" : true
        },
        {
            "_id" : 1,
            "name" : "d1:27017",
            "health" : 1,
            "state" : 2,
            "stateStr" : "SECONDARY",
            "uptime" : 130,
            "optime" : Timestamp(1410273220, 1),
            "optimeDate" : ISODate("2014-09-09T14:33:40Z"),
            "lastHeartbeat" : ISODate("2014-09-09T14:34:28Z"),
            "lastHeartbeatRecv" : ISODate("2014-09-09T14:34:28Z"),
            "pingMs" : 0,
            "syncingTo" : "d2:27017"
        },
        {
            "_id" : 2,
            "name" : "d2:27017",
            "health" : 1,
            "state" : 1,
            "stateStr" : "PRIMARY",
            "uptime" : 130,
            "optime" : Timestamp(1410273220, 1),
            "optimeDate" : ISODate("2014-09-09T14:33:40Z"),
            "lastHeartbeat" : ISODate("2014-09-09T14:34:28Z"),
            "lastHeartbeatRecv" : ISODate("2014-09-09T14:34:28Z"),
            "pingMs" : 0,
            "electionTime" : Timestamp(1410273148, 1),
            "electionDate" : ISODate("2014-09-09T14:32:28Z")
        }
    ],
    "ok" : 1
}
```

The config server:

```
configsvr> db.shards.find()
{ "_id" : "rs_default", "host" : "rs_default/d0:27017,d1:27017,d2:27017" }
```
