### PR TITLE
Locking mongo gem to specific version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,6 +106,6 @@ default[:mongodb][:key_file_content] = nil
 # install the mongo and bson_ext ruby gems at compile time to make them globally available
 # TODO: remove bson_ext once mongo gem supports bson >= 2
 default['mongodb']['ruby_gems'] = {
-  :mongo => nil,
+  :mongo => '1.10.2',
   :bson_ext => nil
 }

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -1,5 +1,5 @@
 chef_gem 'mongo' do
-  version "1.10.2"
+  version '1.10.2'
 end
 
 # Set default to true if this recipe is included

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -1,4 +1,6 @@
-chef_gem 'mongo'
+chef_gem 'mongo' do
+  version "1.10.2"
+end
 
 # Set default to true if this recipe is included
 node.default['mongodb']['config']['auth'] = true


### PR DESCRIPTION
It seems like after an [update to the mongo ruby gem](https://github.com/mongodb/mongo-ruby-driver/releases), unable to run the recipe successfully on Ubuntu 12.04. Just am getting:

``` sh
================================================================================       
Error executing action `install` on resource 'chef_gem[mongo]'       
================================================================================       


Gem::Installer::ExtensionBuildError       
-----------------------------------       
ERROR: Failed to build gem native extension.       

        /opt/chef/embedded/bin/ruby extconf.rb       
checking for sasl/sasl.h... no       
checking for sasl_version() in -lsasl2... no       
creating Makefile       

make       
compiling csasl.c       
csasl.c:16:23: fatal error: sasl/sasl.h: No such file or directory       
compilation terminated.       
make: *** [csasl.o] Error 1       


Gem files will remain installed in /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mongo-1.11.0 for inspection.       
Results logged to /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/mongo-1.11.0/ext/csasl/gem_make.out
```

This change just locks it to a specific version that works, though ideally we'd want to eventually figure out why the change broke the cookbook.
