### PR TITLE
Fixes #355 gem build by providing SASL first

### DIFF
--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -6,6 +6,16 @@ gcc = package 'gcc' do
 end
 gcc.run_action(:install)
 
+if platform_family?('rhel')
+  sasldev_pkg = 'cyrus-sasl-devel'
+else
+  sasldev_pkg = 'libsasl2-dev'
+}
+
+package sasldev_pkg do
+  action :nothing
+end.run_action(:install)
+
 node['mongodb']['ruby_gems'].each do |gem, version|
   chef_gem gem do
     version version


### PR DESCRIPTION
See also https://github.com/mongodb/mongo-ruby-driver/pull/459 for sasl requirements of mongo driver.
