### PR TITLE
Bracket should be 'end' in recipes/mongo_gen.rb

### DIFF
--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -10,7 +10,6 @@ if platform_family?('rhel')
   sasldev_pkg = 'cyrus-sasl-devel'
 else
   sasldev_pkg = 'libsasl2-dev'
-}
 
 package sasldev_pkg do
   action :nothing

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -10,6 +10,7 @@ if platform_family?('rhel')
   sasldev_pkg = 'cyrus-sasl-devel'
 else
   sasldev_pkg = 'libsasl2-dev'
+end 
 
 package sasldev_pkg do
   action :nothing


### PR DESCRIPTION
I noticed what I'm pretty sure is a typo in mongo_gem.rb after attempting and failing to use the replicaset recipe on aws. After forking and changing this end bracket to 'end', I was able to deploy successfully.
