### PR TITLE
User management in replicasets / sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,14 @@ the `node['mongodb']['config']['auth']` attribute to true in the chef json.
 
 If the auth configuration is true, it will try to create the `node['mongodb']['admin']` user, or
 update them if they already exist. Before using on a new database, ensure you're overwriting
-the `node['mongodb']['admin']['username']` and `node['mongodb']['admin']['password']` to
+the `node['mongodb']['authentication']['username']` and `node['mongodb']['authetication']['password']` to
 something besides their default values.
+
+To update the admin username or password after already having deployed the recipe with authentication
+as required, simply change `node['mongodb']['admin']['password']` to the new password while keeping the
+value of `node['mongodb']['authentication']['password']` the old value. After the recipe runs successfully,
+be sure to change the latter variable to the new password so that subsequent attempts to authenticate will
+work.
 
 There's also a user resource which has the actions `:add`, `:modify` and `:delete`. If modify is
 used on a user that doesn't exist, it will be added. If add is used on a user that exists, it

--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ will be modified.
 
 If using this recipe with replication and sharding, ensure that the `node['mongodb']['key_file_content']`
 is set. All nodes must have the same key file in order for the replica set to initialize successfully
-when authentication is required.
+when authentication is required. For mongos instances, set `node['mongodb']['mongos_create_admin']` to
+`true` to force the creation of the admin user on mongos instances.
 
 # LICENSE and AUTHOR:
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ the `node['mongodb']['config']['auth']` attribute to true in the chef json.
 
 If the auth configuration is true, it will try to create the `node['mongodb']['admin']` user, or
 update them if they already exist. Before using on a new database, ensure you're overwriting
-the `node['mongodb']['authentication']['username']` and `node['mongodb']['authetication']['password']` to
+the `node['mongodb']['authentication']['username']` and `node['mongodb']['authentication']['password']` to
 something besides their default values.
 
 To update the admin username or password after already having deployed the recipe with authentication

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ There's also a user resource which has the actions `:add`, `:modify` and `:delet
 used on a user that doesn't exist, it will be added. If add is used on a user that exists, it
 will be modified.
 
+If using this recipe with replication and sharding, ensure that the `node['mongodb']['key_file_content']`
+is set. All nodes must have the same key file in order for the replica set to initialize successfully
+when authentication is required.
+
 # LICENSE and AUTHOR:
 
 Author:: Markus Korn <markus.korn@edelight.de>

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -6,10 +6,19 @@ default['mongodb']['authentication']['password'] = 'admin'
 default['mongodb']['admin'] = {
   'username' => default['mongodb']['authentication']['username'],
   'password' => default['mongodb']['authentication']['password'],
-  'roles' => %w(userAdminAnyDatabase dbAdminAnyDatabase),
+  'roles' => %w(userAdminAnyDatabase dbAdminAnyDatabase clusterAdmin),
   'database' => 'admin'
 }
 
 default['mongodb']['users'] = []
 
+# Force creation of admin user. auth=true is an invalid
+# setting for mongos so this is needed to ensure the admin
+# user is created
 default['mongodb']['mongos_create_admin'] = false
+
+# For mongod replicasets, the delay in seconds and number
+# of times to retry adding a user. Used to handle election
+# of primary not being completed immediately
+default['mongodb']['mongod_create_user']['retries'] = 2
+default['mongodb']['mongod_create_user']['delay'] = 10

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -1,3 +1,6 @@
+default['mongodb']['authentication']['username'] = 'admin'
+default['mongodb']['authentication']['password'] = 'admin'
+
 default['mongodb']['admin'] = {
   'username' => 'admin',
   'password' => 'admin',

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -17,6 +17,11 @@ default['mongodb']['users'] = []
 # user is created
 default['mongodb']['mongos_create_admin'] = false
 
+# For connecting to mongo on localhost, retries to make after
+# connection failures and delay in seconds to retry
+default['mongodb']['user_management']['connection']['retries'] = 1
+default['mongodb']['user_management']['connection']['delay'] = 1
+
 # For mongod replicasets, the delay in seconds and number
 # of times to retry adding a user. Used to handle election
 # of primary not being completed immediately

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -1,9 +1,11 @@
+# The username / password combination that is used
+# to authenticate with the mongo database
 default['mongodb']['authentication']['username'] = 'admin'
 default['mongodb']['authentication']['password'] = 'admin'
 
 default['mongodb']['admin'] = {
-  'username' => 'admin',
-  'password' => 'admin',
+  'username' => default['mongodb']['authentication']['username'],
+  'password' => default['mongodb']['authentication']['password'],
   'roles' => %w(userAdminAnyDatabase dbAdminAnyDatabase),
   'database' => 'admin'
 }

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -6,3 +6,5 @@ default['mongodb']['admin'] = {
 }
 
 default['mongodb']['users'] = []
+
+default['mongodb']['mongos_create_admin'] = false

--- a/attributes/users.rb
+++ b/attributes/users.rb
@@ -19,8 +19,8 @@ default['mongodb']['mongos_create_admin'] = false
 
 # For connecting to mongo on localhost, retries to make after
 # connection failures and delay in seconds to retry
-default['mongodb']['user_management']['connection']['retries'] = 1
-default['mongodb']['user_management']['connection']['delay'] = 1
+default['mongodb']['user_management']['connection']['retries'] = 2
+default['mongodb']['user_management']['connection']['delay'] = 2
 
 # For mongod replicasets, the delay in seconds and number
 # of times to retry adding a user. Used to handle election

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -236,7 +236,10 @@ class Chef::ResourceDefinitionList::MongoDB
     Chef::Log.info(shard_members.inspect)
 
     begin
-      connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5)
+      connection = nil
+      rescue_connection_failure do
+        connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5)
+      end
     rescue => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['config']['port']}', reason #{e}")
       return
@@ -276,7 +279,10 @@ class Chef::ResourceDefinitionList::MongoDB
     require 'mongo'
 
     begin
-      connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5)
+      connection = nil
+      rescue_connection_failure do
+        connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5)
+      end
     rescue => e
       Chef::Log.warn("Could not connect to database: 'localhost:#{node['mongodb']['config']['port']}', reason #{e}")
       return

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -244,6 +244,15 @@ class Chef::ResourceDefinitionList::MongoDB
 
     admin = connection['admin']
 
+    # If we require authentication on mongos / mongod, need to authenticate to run these commands
+    if node.recipe?('mongodb::user_management')
+      begin
+        admin.authenticate(node['mongodb']['authentication']['username'], node['mongodb']['authentication']['password'])
+      rescue Mongo::AuthenticationError => e
+        Chef::Log.warn("Unable to authenticate with database to add shards to mongos node: #{e}")
+      end
+    end
+
     shard_members.each do |shard|
       cmd = BSON::OrderedHash.new
       cmd['addShard'] = shard
@@ -274,6 +283,15 @@ class Chef::ResourceDefinitionList::MongoDB
     end
 
     admin = connection['admin']
+
+    # If we require authentication on mongos / mongod, need to authenticate to run these commands
+    if node.recipe?('mongodb::user_management')
+      begin
+        admin.authenticate(node['mongodb']['authentication']['username'], node['mongodb']['authentication']['password'])
+      rescue Mongo::AuthenticationError => e
+        Chef::Log.warn("Unable to authenticate with database to configure databased on mongos node: #{e}")
+      end
+    end
 
     databases = sharded_collections.keys.map { |x| x.split('.').first }.uniq
     Chef::Log.info("enable sharding for these databases: '#{databases.inspect}'")

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -21,9 +21,9 @@ def add_user(username, password, roles = [], database)
   # must authenticate as a userAdmin after an admin user has been created
   # this will fail on the first attempt, but user will still be created
   # because of the localhost exception
-  if node['mongodb']['config']['auth'] == true
+  if @new_resource.connection['config']['auth'] == true
     begin
-      admin.authenticate(@new_resource.connection['admin']['username'], @new_resource.connection['admin']['password'])
+      admin.authenticate(@new_resource.connection['authentication']['username'], @new_resource.connection['authentication']['password'])
     rescue Mongo::AuthenticationError => e
       Chef::Log.warn("Unable to authenticate as admin user. If this is a fresh install, ignore warning: #{e}")
     end
@@ -44,7 +44,7 @@ def delete_user(username, database)
   admin = connection.db('admin')
   db = connection.db(database)
 
-  admin.authenticate(@new_resource.connection['admin']['username'], @new_resource.connection['admin']['password'])
+  admin.authenticate(@new_resource.connection['authentication']['username'], @new_resource.connection['authentication']['password'])
 
   if user_exists?(username, connection)
     db.remove_user(username)

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -46,16 +46,16 @@ def add_user(username, password, roles = [], database)
           result = admin.command(cmd)
           # Check if the current node in the replicaset status has an info message set (at this point, most likely
           # a message about the election)
-          hasInfoMessage = result['members'].select { |a| a['self'] && a.has_key?('infoMessage')}.count > 0
+          has_info_message = result['members'].select { |a| a['self'] && a.key?('infoMessage') }.count > 0
           if result['myState'] == 1
             # This node is a primary node, try to add the user
             db.add_user(username, password, false, :roles => roles)
             Chef::Log.info("Created or updated user #{username} on #{database} of primary replicaset node")
             break
-          elsif result['myState'] == 2 && hasInfoMessage == true
+          elsif result['myState'] == 2 && has_info_message == true
             # This node is secondary but may be in the process of an election, retry
             Chef::Log.info("Unable to add user to secondary, election may be in progress, retrying in #{@new_resource.connection['mongod_create_user']['delay']} seconds...")
-          elsif result['myState'] == 2 && hasInfoMessage == false
+          elsif result['myState'] == 2 && has_info_message == false
             # This node is secondary and not in the process of an election, bail out
             Chef::Log.info('Current node appears to be a secondary node in replicaset, could not detect election in progress, not adding user')
             break
@@ -64,7 +64,7 @@ def add_user(username, password, roles = [], database)
           # Unable to connect to the node, may not be initialized yet
           Chef::Log.warn("Unable to add user, retrying in #{@new_resource.connection['mongod_create_user']['delay']} second(s)... #{e}")
         rescue Mongo::OperationFailure => e
-          # Unable to make either add call or replicaset call on node, should retry incase it was in the middle of being initialized
+          # Unable to make either add call or replicaset call on node, should retry in case it was in the middle of being initialized
           Chef::Log.warn("Unable to add user, retrying in #{@new_resource.connection['mongod_create_user']['delay']} second(s)... #{e}")
         end
         i += 1

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -13,8 +13,8 @@ def add_user(username, password, roles = [], database)
   # Check if user is admin / admin, and warn that this should
   # be overridden to unique values
   if username == 'admin' && password == 'admin'
-    Chef::Log.warn('Default username / password detected for admin user');
-    Chef::Log.warn('These should be overridden to different, unique values');
+    Chef::Log.warn('Default username / password detected for admin user')
+    Chef::Log.warn('These should be overridden to different, unique values')
   end
 
   # If authentication is required on database

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -31,8 +31,16 @@ def add_user(username, password, roles = [], database)
 
   # Create the user if they don't exist
   # Update the user if they already exist
-  db.add_user(username, password, false, :roles => roles)
-  Chef::Log.info("Created or updated user #{username} on #{database}")
+  begin
+    db.add_user(username, password, false, :roles => roles)
+    Chef::Log.info("Created or updated user #{username} on #{database}")
+  rescue Mongo::ConnectionFailure => e
+    if @new_resource.connection['is_replicaset']
+      Chef::Log.warn("Unable to add user, if this is a secondary replica, ignore: #{e}")
+    else
+      Chef::Log.fatal("Unable to add user: #{e}")
+    end
+  end
 end
 
 # Drop a user from the database specified

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -21,7 +21,7 @@ def add_user(username, password, roles = [], database)
   # must authenticate as a userAdmin after an admin user has been created
   # this will fail on the first attempt, but user will still be created
   # because of the localhost exception
-  if node['mongodb']['config']['auth'] == true
+  if (node['mongodb']['config']['auth'] == true) || (node['mongodb']['mongos_create_admin'] == true)
     begin
       admin.authenticate(@new_resource.connection['admin']['username'], @new_resource.connection['admin']['password'])
     rescue Mongo::AuthenticationError => e

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -5,7 +5,7 @@ admin = node['mongodb']['admin']
 
 # If authentication is required,
 # add the admin to the users array for adding/updating
-users << admin if node['mongodb']['config']['auth'] == true
+users << admin if (node['mongodb']['config']['auth'] == true) || (node['mongodb']['mongos_create_admin'] == true)
 
 users.concat(node['mongodb']['users'])
 

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -16,10 +16,11 @@ users.each do |user|
     roles user['roles']
     database user['database']
     connection node['mongodb']
-    if node['mongodb']['is_replicaset']
-      # If it's a replicaset, don't make any users until the set is initialized
+    if node.recipe?('mongodb::mongos') || node.recipe?('mongodb::replicaset')
+      # If it's a replicaset or mongos, don't make any users until the end
       action :nothing
       subscribes :add, 'ruby_block[config_replicaset]', :delayed
+      subscribes :add, 'ruby_block[config_sharding]', :delayed
     end
   end
 end

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -19,7 +19,7 @@ users.each do |user|
     if node['mongodb']['is_replicaset']
       # If it's a replicaset, don't make any users until the set is initialized
       action :nothing
-      subscribes :add, 'ruby_block[config_replicaset]', :immediately
+      subscribes :add, 'ruby_block[create_replicaset_users]', :delayed
     end
   end
 end

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -16,6 +16,10 @@ users.each do |user|
     roles user['roles']
     database user['database']
     connection node['mongodb']
-    action :add
+    if node['mongodb']['is_replicaset']
+      # If it's a replicaset, don't make any users until the set is initialized
+      action :nothing
+      subscribes :add, 'ruby_block[config_replicaset]', :immediately
+    end
   end
 end

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -19,7 +19,7 @@ users.each do |user|
     if node['mongodb']['is_replicaset']
       # If it's a replicaset, don't make any users until the set is initialized
       action :nothing
-      subscribes :add, 'ruby_block[create_replicaset_users]', :delayed
+      subscribes :add, 'ruby_block[config_replicaset]', :delayed
     end
   end
 end


### PR DESCRIPTION
The goal of this PR is to fix the inability to create users in a sharded / replicaset cluster. The main problems were:
1. It was basing whether to authenticate with the node / create the admin user based on `node[mongodb][config][auth] = true`. However, `auth=true` is not a valid ini setting for mongos instances, so mongos would fail to start. (Solved this by creating a separate variable called `mongos_create_admin` which should be set to `true` on mongos instances.)
2. The mongo ruby driver would fail to connect to mongo while it was in the process of configuring the nodes for replicaset and sharding. According to the [FAQ](https://github.com/mongodb/mongo-ruby-driver/wiki/FAQ#i-periodically-see-connection-failures-between-the-driver-and-mongodb-why-cant-the-driver-retry-the-operation-automatically), reconnections are not handled by the driver, and should be handled solely by the application. (Solved by adding in retires, similar to ones that already existed in the `libraries` file.)

This PR also includes the separation of `[admin][user/pass]` and `[authentication][user/pass]` so that users should be able to change the administrator password of existing administrators.

An example of this working in chef-solo Vagrant [can be found here](https://github.com/ceejh/mongodb-cluster/tree/user-mangement).

Issues: #333, #327, #326
