### PR TITLE
Default PID path for mongod to ensure that it works with systemd on Fedora

### DIFF
--- a/attributes/dbconfig.rb
+++ b/attributes/dbconfig.rb
@@ -21,6 +21,7 @@ default['mongodb']['config']['logappend'] = true
 case node['platform_family']
 when 'rhel', 'fedora'
   default['mongodb']['config']['fork'] = true
+  default['mongodb']['config']['pidfilepath'] = '/var/run/mongodb/mongodb.pid'
 else
   default['mongodb']['config']['fork'] = false
 end


### PR DESCRIPTION
Fedora uses systemd for managing services.  The configuration file for mongodb by default omits the creation of a PID file on the disk at the location that SYSTEMD expects it, therefore the systemd start command never registers mongod as having started.
