### PR TITLE
Fix starting mongodb under RHEL/CentOS 7 with systemctl

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,11 @@ platforms:
   run_list:
   - "recipe[apt]"
 
+- name: centos-7.0
+  run_list:
+  - "recipe[yum]"
+  - "recipe[yum-epel]"
+
 - name: centos-6.5
   run_list:
   - "recipe[yum]"

--- a/templates/default/redhat-mongodb.init.erb
+++ b/templates/default/redhat-mongodb.init.erb
@@ -5,8 +5,7 @@
 # chkconfig: 35 85 15
 # description: Mongo is a scalable, document-oriented database.
 # processname: <%= @provides %>
-# config: /etc/mongod.conf
-# pidfile: /var/run/mongo/mongo.pid
+# config: <%= @dbconfig_file %>
 
 . /etc/rc.d/init.d/functions
 


### PR DESCRIPTION
As noted in #330, the cookbook currently fails to start under CentOS 7. This pull request should fix that. Here's a description of the changes:
- The main issue was that systemctl seems to pay particular attention to the `pidfile` comment that was in the header of the init script. Since a pidfile wasn't actually being written, this was causing systemctl to wait indefinitely thinking the process never started. I removed the `pidfile` reference in the init script, and that allows the service to start.
- When init scripts are changed on disk after they're installed, systemctl wants you to run `systemctl daemon-reload`. This action is now performed anytime the init script is modified, but only on RHEL 7+ systems.
- I also updated the `config` comment in the init script to reference the correct config file. I'm not sure if systemctl cares as much about this setting, but I noticed it was incorrect (it referenced mongod.conf instead of mongodb.conf), so given the pidfile comment issues, I went ahead and updated that to be correct.
