### PR TITLE
Switch to using build-essentials cookbook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem 'chefspec',   '~> 4.0'
 # gem 'foodcritic', '~> 3.0'
 gem 'rake',       '~> 10.1'
 gem 'rubocop',    '~> 0.24.0'
+# This is so we can test on Ruby 1.9.3
+gem 'chef',       '< 12'
 
 group :integration do
     gem 'test-kitchen',    '~> 1.2'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# We need build-essential at compile time
+default['build-essential']['compile_time'] = true
+
 # cluster identifier
 default[:mongodb][:client_roles] = []
 default[:mongodb][:cluster_name] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,6 +18,7 @@ depends 'apt', '>= 1.8.2'
 depends 'yum', '>= 3.0'
 depends 'python'
 depends 'runit', '>= 1.5.0'
+depends 'build-essential'
 
 %w(ubuntu debian centos redhat amazon).each do |os|
   supports os

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -1,10 +1,4 @@
-# The build-essential cookbook was not running during the compile phase, install gcc explicitly for rhel so native
-# extensions can be installed
-gcc = package 'gcc' do
-  action :nothing
-  only_if { platform_family?('rhel') }
-end
-gcc.run_action(:install)
+include_recipe 'build-essential'
 
 if platform_family?('rhel')
   sasldev_pkg = 'cyrus-sasl-devel'


### PR DESCRIPTION
This is better than maintaining code in this cookbook. Let the guys maintaining `build-essential` deal with distribution-specific issues and such.

Fixes #277 
