### PR TITLE
Adds ability to use ipaddress instead of fqdn in replicaset

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -87,7 +87,7 @@ class Chef::ResourceDefinitionList::MongoDB
     cmd = BSON::OrderedHash.new
     cmd['replSetInitiate'] = {
       '_id' => name,
-      'members' => rs_members
+      'members' => node['mongodb']['use_ip_address'] ? rs_member_ips : rs_members
     }
 
     begin


### PR DESCRIPTION
This PR adds the ability to use ip address by specifying an attribute [:mongodb][:use_ip_address] instead of the fqdn for replicaset creation.
