### PR TITLE
Add NUMA support to debian-mongodb upstart script

### DIFF
--- a/templates/default/debian-mongodb.upstart.erb
+++ b/templates/default/debian-mongodb.upstart.erb
@@ -14,12 +14,24 @@ start on runlevel [2345]
 stop on runlevel [06]
 
 script
+  # Handle NUMA access to CPUs (SERVER-3574)
+  # This verifies the existence of numactl as well as testing that the command works
+  NUMACTL_ARGS="--interleave=all"
+  if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
+  then
+      NUMACTL="`which numactl` -- $NUMACTL_ARGS"
+      DAEMON_OPTS="$DAEMON_OPTS"
+  else
+      NUMACTL=""
+      DAEMON_OPTS="-- $DAEMON_OPTS"
+  fi
+
   NAME=<%= @provides %>
   ENABLE_MONGOD="yes"
   if [ -f <%= @sysconfig_file %> ]; then
     . <%= @sysconfig_file %>;
   fi
   if [ "x$ENABLE_MONGOD" = "xyes" ]; then
-  exec start-stop-daemon --start --quiet --chuid $DAEMON_USER --exec $DAEMON -- $DAEMON_OPTS
+  exec start-stop-daemon --start --quiet --chuid $DAEMON_USER --exec $NUMACTL $DAEMON $DAEMON_OPTS
   fi
 end script


### PR DESCRIPTION
Adapted from Debian init.d script which already contains this support.
