### PR TITLE
Moved the ulimit commands to the start function

### DIFF
--- a/templates/default/redhat-mongodb.init.erb
+++ b/templates/default/redhat-mongodb.init.erb
@@ -38,6 +38,13 @@ fi
 
 start()
 {
+  ulimit -f <%= @ulimit['fsize'] %>
+  ulimit -t <%= @ulimit['cpu'] %>
+  ulimit -v <%= @ulimit['as'] %>
+  ulimit -n <%= @ulimit['nofile'] %>
+  ulimit -m <%= @ulimit['rss'] %>
+  ulimit -u <%= @ulimit['nproc'] %>
+
   echo -n $"Starting <%= @provides %>: "
   daemon --user "$DAEMON_USER" $NUMACTL $DAEMON $DAEMON_OPTS
   RETVAL=$?
@@ -62,13 +69,6 @@ restart () {
   stop
   start
 }
-
-ulimit -f <%= @ulimit['fsize'] %>
-ulimit -t <%= @ulimit['cpu'] %>
-ulimit -v <%= @ulimit['as'] %>
-ulimit -n <%= @ulimit['nofile'] %>
-ulimit -m <%= @ulimit['rss'] %>
-ulimit -u <%= @ulimit['nproc'] %>
 
 RETVAL=0
 


### PR DESCRIPTION
The placement of the `ulimit` calls in the current init script for Red Hat systems results in the commands being called every time the script is called. This means that

```
$ service mongod start
$ service mongod stop
$ service mongod status
$ service mongod restart
```

all result in the `ulimit` calls being executed.

As far as I can see, this is unnecessary - they only need to be called when the service is starting.

While this isn't a problem itself, it can lead to some confusion. If a user runs

```
$ sudo service mongod start
$ service mongo status
```

he'll receive

```
/etc/init.d/mongod: line 70: ulimit: open files: cannot modify limit: Operation not permitted
/etc/init.d/mongod: line 72: ulimit: max user processes: cannot modify limit: Operation not permitted
mongod (pid 13466) is running...
```

MongoDB did start correctly... but the `ulimit` calls were executed again when the user attempted to get the service's status. Because the user didn't run it with `root` privileges, the calls failed and resulted in an error. Once again, it's not a problem, but it can be confusing.

&mdash; @citruspi 
