### PR TITLE
Get rid of chef_gem.

### DIFF
--- a/recipes/mongos.rb
+++ b/recipes/mongos.rb
@@ -24,7 +24,15 @@ node.set['mongodb']['shard_name'] = node['mongodb']['shard_name']
 node.override['mongodb']['instance_name'] = 'mongos'
 
 include_recipe 'mongodb::install'
-include_recipe 'mongodb::mongo_gem'
+
+ruby_block 'chef_gem_at_converge_time' do·
+  block do
+    node['mongodb']['ruby_gems'].each do |gem, version|
+      version = Gem::Dependency.new(gem, version)
+      Chef::Provider::Package::Rubygems::GemEnvironment.new.install(version)
+    end
+  end
+end
 
 service node[:mongodb][:default_init_name] do
   action [:disable, :stop]

--- a/recipes/replicaset.rb
+++ b/recipes/replicaset.rb
@@ -21,7 +21,15 @@ node.set['mongodb']['is_replicaset'] = true
 node.set['mongodb']['cluster_name'] = node['mongodb']['cluster_name']
 
 include_recipe 'mongodb::install'
-include_recipe 'mongodb::mongo_gem'
+
+ruby_block 'chef_gem_at_converge_time' do·
+  block do
+    node['mongodb']['ruby_gems'].each do |gem, version|
+      version = Gem::Dependency.new(gem, version)
+      Chef::Provider::Package::Rubygems::GemEnvironment.new.install(version)
+    end
+  end
+end
 
 unless node['mongodb']['is_shard']
   mongodb_instance node['mongodb']['instance_name'] do


### PR DESCRIPTION
chef_gem fails because build-essential isn't installed at compile time.
The Chef guys are recommending that complex things like replicaset and
mongos become LWRPs, which is probably in progress but this fixes the
chef_gem issue quickly.
