### PR TITLE
Fixing defaults for Ubuntu with MongoDB > 2.6

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,6 +92,13 @@ when 'debian'
     default[:mongodb][:apt_repo] = 'ubuntu-upstart'
     default[:mongodb][:init_dir] = '/etc/init/'
     default[:mongodb][:init_script_template] = 'debian-mongodb.upstart.erb'
+
+    unless node['version'] && node['version'] < '2.6'
+      default[:mongodb][:instance_name] = 'mongod'
+      default[:mongodb][:default_init_name] = 'mongod'
+      default[:mongodb][:dbconfig_file] = '/etc/mongod.conf'
+      default[:mongodb][:sysconfig_file] = '/etc/default/mongod'
+    end 
   else
     default[:mongodb][:apt_repo] = 'debian-sysvinit'
   end


### PR DESCRIPTION
Official packages for MongoDB greater than 2.6 drop default configuration files at:
- `/etc/mongod.conf`
- `/etc/default/mongod`
- `/etc/init/mongod.conf`

This recipe had to have some defaults manually set to reflect this. Failing to set any defaults would result in a MongoDB install that couldn't be configured from Chef. Setting some (but not all) of these defaults would result in duplicate configuration files. At best, this was confusing to debug. At worst, it created two sets of services, when only one was intended. Pull request #331 reflects this confusion.

This PR sets defaults in line with what the official package installs for Ubuntu with Upstart and MongoDB greater than 2.6.
