### PR TITLE
Cookbook doesn't work on Amazon Linux

### DIFF
--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -193,7 +193,7 @@ define :mongodb_instance,
     )
     notifies new_resource.reload_action, "service[#{new_resource.name}]"
 
-    if(platform_family?('rhel') && node['platform_version'].to_i >= 7)
+    if(platform_family?('rhel') && node['platform'] != 'amazon' && node['platform_version'].to_i >= 7)
       notifies :run, 'execute[mongodb-systemctl-daemon-reload]', :immediately
     end
   end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -55,7 +55,7 @@ template init_file do
   )
   action :create_if_missing
 
-  if(platform_family?('rhel') && node['platform_version'].to_i >= 7)
+  if(platform_family?('rhel') && node['platform'] != 'amazon' && node['platform_version'].to_i >= 7)
     notifies :run, 'execute[mongodb-systemctl-daemon-reload]', :immediately
   end
 end


### PR DESCRIPTION
Excluded Amazon Linux from using systemctl since they haven't upgraded to systemd but their version number doesn't match standard RHEL versioning
