### PR TITLE
Packager Options Attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -56,13 +56,13 @@ case node['platform_family']
 when 'debian'
   # this options lets us bypass complaint of pre-existing init file
   # necessary until upstream fixes ENABLE_MONGOD/DB flag
-  default[:mongodb][:packager_opts] = '-o Dpkg::Options::="--force-confold" --force-yes'
+  default[:mongodb][:packager_options] = '-o Dpkg::Options::="--force-confold" --force-yes'
 when 'rhel'
   # Add --nogpgcheck option when package is signed
   # see: https://jira.mongodb.org/browse/SERVER-8770
-  default[:mongodb][:packager_opts] = '--nogpgcheck'
+  default[:mongodb][:packager_options] = '--nogpgcheck'
 else
-  default[:mongodb][:packager_opts] = ''
+  default[:mongodb][:packager_options] = ''
 end
 
 default[:mongodb][:default_init_name] = 'mongodb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,19 @@ default[:mongodb][:dbconfig_file] = '/etc/mongodb.conf'
 default[:mongodb][:package_name] = 'mongodb'
 default[:mongodb][:package_version] = nil
 
+case node['platform_family']
+when 'debian'
+  # this options lets us bypass complaint of pre-existing init file
+  # necessary until upstream fixes ENABLE_MONGOD/DB flag
+  default[:mongodb][:packager_opts] = '-o Dpkg::Options::="--force-confold" --force-yes'
+when 'rhel'
+  # Add --nogpgcheck option when package is signed
+  # see: https://jira.mongodb.org/browse/SERVER-8770
+  default[:mongodb][:packager_opts] = '--nogpgcheck'
+else
+  default[:mongodb][:packager_opts] = ''
+end
+
 default[:mongodb][:default_init_name] = 'mongodb'
 default[:mongodb][:instance_name] = 'mongodb'
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -60,22 +60,9 @@ template init_file do
   end
 end
 
-case node['platform_family']
-when 'debian'
-  # this options lets us bypass complaint of pre-existing init file
-  # necessary until upstream fixes ENABLE_MONGOD/DB flag
-  packager_opts = '-o Dpkg::Options::="--force-confold" --force-yes'
-when 'rhel'
-  # Add --nogpgcheck option when package is signed
-  # see: https://jira.mongodb.org/browse/SERVER-8770
-  packager_opts = '--nogpgcheck'
-else
-  packager_opts = ''
-end
-
 # install
 package node[:mongodb][:package_name] do
-  options packager_opts
+  options node[:mongodb][:packager_options]
   action :install
   version node[:mongodb][:package_version]
 end


### PR DESCRIPTION
The cookbook currently sets packager options for use when installing MongoDB. Unfortunately, it's not available as an attribute, which means that the packager options can't be modified without forking the cookbook.

This changes that, moving the code used to determine the packager options to the `attributes/default.rb` file and then accessing that in the installation recipe via `node[:mongodb][:packager_options]`.

&mdash; @citruspi
