### PR TITLE
Force rs.reconfig when there are no old members

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,6 +106,7 @@ default[:mongodb][:key_file_content] = nil
 # install the mongo and bson_ext ruby gems at compile time to make them globally available
 # TODO: remove bson_ext once mongo gem supports bson >= 2
 default['mongodb']['ruby_gems'] = {
-  :mongo => nil,
-  :bson_ext => nil
+  :mongo => '~> 1.12',
+  :bson_ext => nil,
+  'sys-proctable' => '> 0.0.0'
 }

--- a/definitions/mongodb.rb
+++ b/definitions/mongodb.rb
@@ -206,8 +206,8 @@ define :mongodb_instance,
     new_resource.service_notifies.each do |service_notify|
       notifies :run, service_notify
     end
-    notifies :create, 'ruby_block[config_replicaset]', :immediately if new_resource.is_replicaset && new_resource.auto_configure_replicaset
-    notifies :create, 'ruby_block[config_sharding]', :immediately if new_resource.is_mongos && new_resource.auto_configure_sharding
+    notifies :create, 'ruby_block[config_replicaset]' if new_resource.is_replicaset && new_resource.auto_configure_replicaset
+    notifies :create, 'ruby_block[config_sharding]' if new_resource.is_mongos && new_resource.auto_configure_sharding
       # we don't care about a running mongodb service in these cases, all we need is stopping it
     ignore_failure true if new_resource.name == 'mongodb'
   end

--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -55,6 +55,7 @@ class Chef::ResourceDefinitionList::MongoDB
     members.each_index do |n|
       host = "#{members[n]['fqdn']}:#{members[n]['mongodb']['config']['port']}"
       rs_options[host] = {}
+
       rs_options[host]['arbiterOnly'] = true if members[n]['mongodb']['replica_arbiter_only']
       rs_options[host]['buildIndexes'] = false unless members[n]['mongodb']['replica_build_indexes']
       rs_options[host]['hidden'] = true if members[n]['mongodb']['replica_hidden']
@@ -98,7 +99,7 @@ class Chef::ResourceDefinitionList::MongoDB
     end
     if result.fetch('ok', nil) == 1
       # everything is fine, do nothing
-    elsif result.fetch('errmsg', nil) =~ /(\S+) is already initiated/ || (result.fetch('errmsg', nil) == 'already initialized')
+    elsif result.fetch('errmsg', nil) =~ /(\S+) is already initiated/ || (result.fetch('errmsg', nil) == 'already initialized') || (result.fetch('errmsg', nil) =~ /is not empty on the initiating member/)
       server, port = Regexp.last_match.nil? || Regexp.last_match.length < 2 ? ['localhost', node['mongodb']['config']['port']] : Regexp.last_match[1].split(':')
       begin
         connection = Mongo::Connection.new(server, port, :op_timeout => 5, :slave_ok => true)
@@ -108,7 +109,6 @@ class Chef::ResourceDefinitionList::MongoDB
 
       # check if both configs are the same
       config = connection['local']['system']['replset'].find_one('_id' => name)
-
       if config['_id'] == name && config['members'] == rs_members
         # config is up-to-date, do nothing
         Chef::Log.info("Replicaset '#{name}' already configured")
@@ -155,6 +155,7 @@ class Chef::ResourceDefinitionList::MongoDB
         end
         Chef::Log.error("configuring replicaset returned: #{result.inspect}") unless result.fetch('errmsg', nil).nil?
       else
+        Chef::Log.info "going to add and remove members from the replicaset"
         # remove removed members from the replicaset and add the new ones
         max_id = config['members'].map { |member| member['_id'] }.max
         rs_members.map! { |member| member['host'] }
@@ -166,16 +167,27 @@ class Chef::ResourceDefinitionList::MongoDB
           host = m['host']
           { '_id' => m['_id'], 'host' => host }.merge(rs_options[host])
         end
+        Chef::Log.info "after removing members, config = #{config}"
+        remaining_members = config['members'].count
         members_add = rs_members - old_members
         members_add.each do |m|
           max_id += 1
           config['members'] << { '_id' => max_id, 'host' => m }.merge(rs_options[m])
         end
+        Chef::Log.info "after adding new members, config = #{config}"
 
         rs_connection = nil
+        force = false
         rescue_connection_failure do
-          rs_connection = Mongo::ReplSetConnection.new(old_members)
-          rs_connection.database_names # check connection
+          case remaining_members
+          when 0
+            force = true
+            rs_connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5, :slave_ok => true)
+            rs_connection.database_names # check connection
+          else
+            rs_connection = Mongo::ReplSetConnection.new(old_members)
+            rs_connection.database_names # check connection
+          end
         end
 
         admin = rs_connection['admin']
@@ -185,7 +197,7 @@ class Chef::ResourceDefinitionList::MongoDB
 
         result = nil
         begin
-          result = admin.command(cmd, :check_response => false)
+          result = admin.command(cmd, :force => force, :check_response => false)
         rescue Mongo::ConnectionFailure
           # reconfiguring destroys existing connections, reconnect
           connection = Mongo::Connection.new('localhost', node['mongodb']['config']['port'], :op_timeout => 5, :slave_ok => true)

--- a/recipes/mongo_gem.rb
+++ b/recipes/mongo_gem.rb
@@ -6,6 +6,12 @@ gcc = package 'gcc' do
 end
 gcc.run_action(:install)
 
+be = package "build-essential" do
+  action :nothing
+  only_if { platform_family?('debian') }
+end
+be.run_action(:install)
+
 if platform_family?('rhel')
   sasldev_pkg = 'cyrus-sasl-devel'
 else


### PR DESCRIPTION
Hi,

I am working on restoring a replicaset from EBS snapshot. When I bring up three new instances with Chef, I hit line 101 of libraries/mongodb.rb, which doesn't match the error message. My returned error message is:

"local.oplog.rs is not empty on the initiating member. cannot initiate."

None of the IP addresses of the new MongoDB servers are the same as they were, previously, because I'm restoring volumes from snapshot. Therefore, if I create a new config document containing the new hostnames and pass it in through rs.reconfig, my replica set comes up.

If I modify line 101:

elsif result.fetch('errmsg', nil) =~ /(\S+) is already initiated/ || (result.fetch('errmsg', nil) == 'already initialized') || (result.fetch('errmsg', nil) =~ /is not empty on the initiating member/)

Then Chef will do this for me, but I'm not sure that it's safe? I'll submit a pull request if it is.

Thanks!
