### PR TITLE
Add retries in user_management.rb

### DIFF
--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -9,6 +9,18 @@ users << admin if node['mongodb']['config']['auth'] == true
 
 users.concat(node['mongodb']['users'])
 
+service 'mongodb' do
+  action :restart
+end
+
+# Retry 5 times to make sure mongodb is started
+execute 'wait for mongodb' do
+  command 'mongo'
+  action :run
+  retries 5
+  retry_delay 10
+end
+
 # Add each user specified in attributes
 users.each do |user|
   mongodb_user user['username'] do


### PR DESCRIPTION
In a fresh install, user_management.rb will break because mongodb server is not started by the time of adding admin user.
By adding retries, we can make sure mongodb server is started before adding admin user.
