### PR TITLE
use mongo gem version 1.X

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,6 +106,6 @@ default[:mongodb][:key_file_content] = nil
 # install the mongo and bson_ext ruby gems at compile time to make them globally available
 # TODO: remove bson_ext once mongo gem supports bson >= 2
 default['mongodb']['ruby_gems'] = {
-  :mongo => nil,
+  :mongo => '~> 1.12',
   :bson_ext => nil
 }

--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -1,4 +1,4 @@
-chef_gem 'mongo'
+include_recipe 'mongodb::mongo_gem'
 
 users = []
 admin = node['mongodb']['admin']


### PR DESCRIPTION
Mongo::MongoClient is no longer available in the mongo gem as of the 2.X release series.  This pull request sets the default mongo gem version to ~> 1.12 and forces the user_management recipe to utilize the mongo_gem recipe instead of installing the mongo gem itself.
