### PR TITLE
Add Mongo 3 repositories

### DIFF
--- a/recipes/mongodb_org_repo.rb
+++ b/recipes/mongodb_org_repo.rb
@@ -35,6 +35,15 @@ when 'debian'
     action :add
   end
 
+  apt_repository 'mongodb' do
+    uri "http://repo.mongodb.org/apt/ubuntu"
+    distribution 'trusty/mongodb-org/stable'
+    components ['multiverse']
+    keyserver 'hkp://keyserver.ubuntu.com:80'
+    key '7F0CEB10'
+    action :add
+  end
+
 when 'rhel', 'fedora'
   yum_repository 'mongodb' do
     description 'mongodb RPM Repository'

--- a/recipes/mongodb_org_repo.rb
+++ b/recipes/mongodb_org_repo.rb
@@ -43,6 +43,14 @@ when 'rhel', 'fedora'
     gpgcheck false
     enabled true
   end
+  
+  yum_repository 'mongodb-org-3.0' do
+      description 'MongoDB Repository'
+      baseurl "https://repo.mongodb.org/yum/redhat/6/mongodb-org/3.0/#{node['kernel']['machine']  =~ /x86_64/ ? 'x86_64' : 'i686'}"
+      action :create
+      gpgcheck false
+      enabled true
+  end
 
 else
   # pssst build from source


### PR DESCRIPTION
I'm not convinced what is in this pull request is the most ideal (i.e. hard-coding "trusty"), but it works for me.

For the yum repository, the "package_version" you have to specify is '3.0.3-1.el6'.

For Ubuntu, you can specify '3.0.3'.
