### PR TITLE
changes for mongodb_org_repo.rb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.1
 bundler_args: --without integration

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,6 +92,7 @@ when 'debian'
     default[:mongodb][:apt_repo] = 'ubuntu-upstart'
     default[:mongodb][:init_dir] = '/etc/init/'
     default[:mongodb][:init_script_template] = 'debian-mongodb.upstart.erb'
+    default[:mongodb][:keyserver] = 'keyserver.ubuntu.com'
   else
     default[:mongodb][:apt_repo] = 'debian-sysvinit'
   end

--- a/recipes/mongodb_org_repo.rb
+++ b/recipes/mongodb_org_repo.rb
@@ -30,7 +30,7 @@ when 'debian'
     uri "http://downloads-distro.mongodb.org/repo/#{node[:mongodb][:apt_repo]}"
     distribution 'dist'
     components ['10gen']
-    keyserver 'hkp://keyserver.ubuntu.com:80'
+    keyserver "#{node[:mongodb][:keyserver]}"
     key '7F0CEB10'
     action :add
   end


### PR DESCRIPTION
I included keyserver in default attributes and it will use in mongodb_org_repo.rb at line 33 keyserver "#{node[:mongodb][:keyserver]}" instead of keyserver 'hkp://keyserver.ubuntu.com:80'
