### PR TITLE
Use gem mongo version 1.x

### DIFF
--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -1,4 +1,6 @@
-chef_gem 'mongo'
+chef_gem 'mongo' do
+  version "1.12.3"
+end
 
 users = []
 admin = node['mongodb']['admin']


### PR DESCRIPTION
The gem "mongo" version 2.x will be installed if no version option is specified, and this recipe does not work with the gem mongo version 2x.
