### PR TITLE
#401: allow using the optional mongodb.fqdn_override attribute to ove…

### DIFF
--- a/libraries/mongodb.rb
+++ b/libraries/mongodb.rb
@@ -54,6 +54,7 @@ class Chef::ResourceDefinitionList::MongoDB
     rs_options = {}
     members.each_index do |n|
       host = "#{members[n]['fqdn']}:#{members[n]['mongodb']['config']['port']}"
+      host = "#{members[n]['mongodb']['fqdn_override']}:#{members[n]['mongodb']['config']['port']}" if members[n]['mongodb']['fqdn_override']
       rs_options[host] = {}
       rs_options[host]['arbiterOnly'] = true if members[n]['mongodb']['replica_arbiter_only']
       rs_options[host]['buildIndexes'] = false unless members[n]['mongodb']['replica_build_indexes']


### PR DESCRIPTION
…rride the fqdn in constructing the hostname.

As describe in #401, we need to have a way to override fqdn to be a specific host name, as the requirement is avoid usage of dynamic aws host names, without DNS updates.

(In our case, the specific host names are static ip's.)

This is one line change that makes this option open. The change does not affect any existing logic when the attribute is missing. Please merge it if this change makes sense. Thank you.
