### PR TITLE
update Berksfile source to point to current url

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "http://api.berkshelf.com"
+source 'https://supermarket.chef.io'
 
 metadata
 


### PR DESCRIPTION
With this fix I am able to download chef-solo-search to run the kitchen
tests.
