### PR TITLE
Fix mongodb user/group on RHEL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,11 +76,11 @@ when 'rhel', 'fedora'
   # verified for RHEL5,6 Fedora 18,19
   default[:mongodb][:package_name] = 'mongodb-server'
   default[:mongodb][:sysconfig_file] = '/etc/sysconfig/mongodb'
-  default[:mongodb][:user] = 'mongod'
-  default[:mongodb][:group] = 'mongod'
+  default[:mongodb][:user] = 'mongodb'
+  default[:mongodb][:group] = 'mongodb'
   default[:mongodb][:init_script_template] = 'redhat-mongodb.init.erb'
-  default[:mongodb][:default_init_name] = 'mongod'
-  default[:mongodb][:instance_name] = 'mongod'
+  default[:mongodb][:default_init_name] = 'mongodb'
+  default[:mongodb][:instance_name] = 'mongodb'
   # then there is this guy
   if node['platform'] == 'centos' || node['platform'] == 'amazon'
     Chef::Log.warn("CentOS doesn't provide mongodb, forcing use of mongodb-org repo")


### PR DESCRIPTION
Hi, not sure if this was intentional or not. But with mongodb user/group set to be "mongod" on RHEL, the cookbook fails out of the box, looking for 'mongod' user/group that are not there, as well as failing to start mongodb because /var/[lib/log/run]/mongodb are owned by mongodb:mongodb. When I changed these attributes to 'mongodb' the cookbook works out the box. Thanks so much for the work.
